### PR TITLE
won't static source code ratio about jupyter notebook

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+bmf/demo/colorization_python/deoldify_demo_colab.ipynb linguist-vendored
+bmf/demo/video_enhance/bmf-enhance-demo.ipynb linguist-vendored
+bmf/demo/gpu_module/gpu_module_demo_colab.ipynb linguist-vendored
+bmf/demo/edit/bmf_edit_python.ipynb linguist-vendored
+bmf/demo/video_frame_extraction/video_frame_extraction_acceleration.ipynb linguist-vendored
+bmf/demo/transcode/bmf_transcode_demo.ipynb linguist-vendored
+bmf/demo/aesthetic_assessment/aesmod_bmfv3_fin.ipynb linguist-vendored
+bmf/test/customize_module/bmf_customize_demo_latest.ipynb linguist-vendored
+bmf/test/sync_mode/bmf_syncmode_cpp.ipynb linguist-vendored
+bmf/test/sync_mode/bmf_syncmode_go.ipynb linguist-vendored
+bmf/test/sync_mode/bmf_syncmode_python.ipynb linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,1 @@
-bmf/demo/colorization_python/deoldify_demo_colab.ipynb linguist-vendored
-bmf/demo/video_enhance/bmf-enhance-demo.ipynb linguist-vendored
-bmf/demo/gpu_module/gpu_module_demo_colab.ipynb linguist-vendored
-bmf/demo/edit/bmf_edit_python.ipynb linguist-vendored
-bmf/demo/video_frame_extraction/video_frame_extraction_acceleration.ipynb linguist-vendored
-bmf/demo/transcode/bmf_transcode_demo.ipynb linguist-vendored
-bmf/demo/aesthetic_assessment/aesmod_bmfv3_fin.ipynb linguist-vendored
-bmf/test/customize_module/bmf_customize_demo_latest.ipynb linguist-vendored
-bmf/test/sync_mode/bmf_syncmode_cpp.ipynb linguist-vendored
-bmf/test/sync_mode/bmf_syncmode_go.ipynb linguist-vendored
-bmf/test/sync_mode/bmf_syncmode_python.ipynb linguist-vendored
+bmf/demo/*/*.ipynb linguist-vendored


### PR DESCRIPTION
首页jupyter notebook统计代码语言占比超过了主要开发语言，忽略该类型文件