### PR TITLE
Add dlpack data import support

### DIFF
--- a/bmf/hml/include/hmp/dataexport/data_export.h
+++ b/bmf/hml/include/hmp/dataexport/data_export.h
@@ -5,4 +5,5 @@
 
 namespace hmp {
 HMP_API DLManagedTensor *to_dlpack(const Tensor &src);
+HMP_API Tensor from_dlpack(const DLManagedTensor* src);
 } // namespace hmp

--- a/bmf/hml/src/dataexport/data_export.cpp
+++ b/bmf/hml/src/dataexport/data_export.cpp
@@ -1,17 +1,16 @@
 #include <hmp/dataexport/data_export.h>
 
 #include <iostream>
+#include <string>
 
 namespace hmp{
-static DLDataType getDLDataType(const Tensor& t) {
+static DLDataType get_dl_dtype(const Tensor& t) {
     DLDataType dtype;
     dtype.lanes = 1;
     dtype.bits = sizeof_scalar_type(t.scalar_type()) * 8;
     switch (t.scalar_type()) {
         case ScalarType::UInt8:
         case ScalarType::UInt16:
-        // case ScalarType::UInt32:
-        // case ScalarType::UInt64:
         dtype.code = DLDataTypeCode::kDLUInt;
         break;
         case ScalarType::Int8:
@@ -32,7 +31,66 @@ static DLDataType getDLDataType(const Tensor& t) {
     return dtype;
 }
 
-static DLDevice getDLDevice(const Tensor& tensor, const int64_t& device_id) {
+ScalarType to_scalar_type(const DLDataType& dtype) {
+  ScalarType stype;
+  HMP_REQUIRE(dtype.lanes == 1, "hmp does not support lanes != 1");
+  switch (dtype.code) {
+    case DLDataTypeCode::kDLUInt:
+      switch (dtype.bits) {
+        case 8:
+          stype = ScalarType::UInt8;
+          break;
+        case 16:
+          stype = ScalarType::UInt16;
+          break;
+        default:
+          HMP_REQUIRE(
+              false, "Unsupported kUInt bits " + std::to_string(dtype.bits));
+      }
+      break;
+    case DLDataTypeCode::kDLInt:
+      switch (dtype.bits) {
+        case 8:
+          stype = ScalarType::Int8;
+          break;
+        case 16:
+          stype = ScalarType::Int16;
+          break;
+        case 32:
+          stype = ScalarType::Int32;
+          break;
+        case 64:
+          stype = ScalarType::Int64;
+          break;
+        default:
+          HMP_REQUIRE(
+              false, "Unsupported kInt bits " + std::to_string(dtype.bits));
+      }
+      break;
+    case DLDataTypeCode::kDLFloat:
+      switch (dtype.bits) {
+        case 16:
+          stype = ScalarType::Half;
+          break;
+        case 32:
+          stype = ScalarType::Float32;
+          break;
+        case 64:
+          stype = ScalarType::Float64;
+          break;
+        default:
+          HMP_REQUIRE(
+              false, "Unsupported kFloat bits " + std::to_string(dtype.bits));
+      }
+      break;
+    default:
+      HMP_REQUIRE(
+          false, "Unsupported code " + std::to_string(dtype.code));
+  }
+  return stype;
+}
+
+static DLDevice get_dl_device(const Tensor& tensor, const int64_t& device_id) {
     DLDevice ctx;
     ctx.device_id = device_id;
     switch (tensor.device().type()) {
@@ -48,14 +106,26 @@ static DLDevice getDLDevice(const Tensor& tensor, const int64_t& device_id) {
     return ctx;
 }
 
+static Device get_hmp_device(const DLDevice& ctx) {
+    switch (ctx.device_type) {
+        case DLDeviceType::kDLCPU:
+        return Device(DeviceType::CPU);
+#ifdef HMP_ENABLE_CUDA
+        case DLDeviceType::kDLCUDA:
+        return Device(DeviceType::CUDA, ctx.device_id);
+#endif
+        default:
+        HMP_REQUIRE(
+            false, "Unsupported device_type: " + std::to_string(ctx.device_type));
+    }
+}
+
 struct HmpDLMTensor {
-    // HmpDLMTensor() { std::cout << "Construct HmpDLMTensor\n"; }
     Tensor handle;
     DLManagedTensor tensor;
 };
 
 void deleter(DLManagedTensor* arg) {
-    // std::cout << "Destruct HmpDLMTensor\n";
     delete static_cast<HmpDLMTensor*>(arg->manager_ctx);
 }
 
@@ -70,9 +140,9 @@ DLManagedTensor* to_dlpack(const Tensor& src) {
     if (src.is_cuda()) {
         device_id = src.device_index();
     }
-    hmpDLMTensor->tensor.dl_tensor.device = getDLDevice(src, device_id);
+    hmpDLMTensor->tensor.dl_tensor.device = get_dl_device(src, device_id);
     hmpDLMTensor->tensor.dl_tensor.ndim = src.dim();
-    hmpDLMTensor->tensor.dl_tensor.dtype = getDLDataType(src);
+    hmpDLMTensor->tensor.dl_tensor.dtype = get_dl_dtype(src);
     hmpDLMTensor->tensor.dl_tensor.shape =
         const_cast<int64_t*>(src.shape().data());
     hmpDLMTensor->tensor.dl_tensor.strides =
@@ -81,4 +151,16 @@ DLManagedTensor* to_dlpack(const Tensor& src) {
     return &(hmpDLMTensor->tensor);
 }
 
+Tensor from_dlpack(
+    const DLManagedTensor* src) {
+    Device device = get_hmp_device(src->dl_tensor.device);
+    ScalarType stype = to_scalar_type(src->dl_tensor.dtype);
+    DataPtr dp{src->dl_tensor.data, device};
+    SizeArray shape{src->dl_tensor.shape, src->dl_tensor.shape + src->dl_tensor.ndim};
+    if (!src->dl_tensor.strides) {
+        return from_buffer({src->dl_tensor.data, device}, stype, shape);
+    }
+    SizeArray strides{src->dl_tensor.strides, src->dl_tensor.strides + src->dl_tensor.ndim};
+    return from_buffer({src->dl_tensor.data, device}, stype, shape, strides);
+}
 } // namespace hmp


### PR DESCRIPTION
Add support for importing data from other frameworks supporting dlpack. The support is on Python level, an example Python code sample importing pytorch tensor to hmp tensor can be:

```Python
import torch
import bmf.hml.hmp as hmp

t = torch.zeros((720, 1280, 2), dtype=torch.uint8)
ht = hmp.from_dlpack(t)
```

Both `cpu` and `cuda` devices are supported.