### PR TITLE
Yuvalloctor

### DIFF
--- a/bmf/hml/include/hmp/ffmpeg/ff_helper.h
+++ b/bmf/hml/include/hmp/ffmpeg/ff_helper.h
@@ -534,7 +534,7 @@ static Frame from_video_frame(const AVFrame *avf) {
 }
 
 // ffmpeg nv12 require
-static bool check_cuda_frame_need_copy_for_ffmpeg(const Frame &frame) {
+static bool check_frame_memory_is_contiguous(const Frame &frame) {
     if (!frame.storage().defined()) {
         return true;
     }
@@ -581,7 +581,7 @@ static AVFrame *to_video_frame(const Frame &frame,
 #ifdef HMP_ENABLE_CUDA
     if (frame.device().type() == kCUDA &&
         (!avf_ref || (avf_ref && !avf_ref->hw_frames_ctx)) &&
-        check_cuda_frame_need_copy_for_ffmpeg(frame)) {
+        check_frame_memory_is_contiguous(frame)) {
         HMP_REQUIRE(frame.pix_info().format() == hmp::PF_NV12,
                     "cuda hardware encode need NV12 frame");
         auto nv12 = bmf_sdk::PixelInfo(hmp::PF_NV12, hmp::CS_BT709);

--- a/bmf/hml/include/hmp/imgproc/image.h
+++ b/bmf/hml/include/hmp/imgproc/image.h
@@ -180,6 +180,14 @@ class HMP_API Frame {
     Frame reformat(const PixelInfo &pix_info);
     const Tensor &storage() const { return storage_tensor_; }
 
+    /**
+     * @brief frame with multiple planes are stored in contiguous memory
+     *
+     * @param
+     * @return Frame
+     */
+    Frame as_contiguous_storage();
+
   private:
     int width_, height_;
     PixelFormatDesc pix_desc_;

--- a/bmf/hml/include/hmp/imgproc/image.h
+++ b/bmf/hml/include/hmp/imgproc/image.h
@@ -31,9 +31,11 @@ class HMP_API Frame {
           const Device &device = kCPU);
 
     Frame(const TensorList &data, int width, int height,
-          const PixelInfo &pix_info);
-    Frame(const TensorList &data, const PixelInfo &pix_info);
-    Frame(const Tensor &data, const PixelInfo &pix_info);
+          const PixelInfo &pix_info, const Tensor &storage_tensor = {});
+    Frame(const TensorList &data, const PixelInfo &pix_info,
+          const Tensor &storage_tensor = {});
+    Frame(const Tensor &data, const PixelInfo &pix_info,
+          const Tensor &storage_tensor = {});
 
     /**
      * @brief check is this frame is defined
@@ -176,14 +178,23 @@ class HMP_API Frame {
      * @return Frame
      */
     Frame reformat(const PixelInfo &pix_info);
+    const Tensor &storage() const { return storage_tensor_; }
 
   private:
     int width_, height_;
     PixelFormatDesc pix_desc_;
     PixelInfo pix_info_;
     TensorList data_;
+
+    /// Each plane of the frame is represented using a tensor
+    /// and we want the memory of multi-planes frame to be allocated
+    /// continuously. This requires an additional member variable to represent a
+    /// contiguous storage space.
+    Tensor storage_tensor_;
 };
 
 HMP_API std::string stringfy(const Frame &frame);
+TensorList from_storage_tensor(const Tensor &storage_tensor,
+                               const TensorList &mirror);
 
 } // namespace hmp

--- a/bmf/hml/include/hmp/tensor.h
+++ b/bmf/hml/include/hmp/tensor.h
@@ -188,6 +188,8 @@ HMP_API Tensor from_buffer(DataPtr &&data, ScalarType scalar_type,
                            const SizeArray &shape,
                            const optional<SizeArray> &strides = nullopt);
 HMP_API Tensor empty(const SizeArray &shape, const TensorOptions &options = {});
+HMP_API Tensor empty_tensor_buffer(const int64_t &nitems,
+                                   const TensorOptions &options = {});
 HMP_API Tensor empty_like(const Tensor &other,
                           const optional<TensorOptions> &options = nullopt);
 HMP_API Tensor zeros(const SizeArray &shape, const TensorOptions &options = {});

--- a/bmf/hml/include/hmp/tensor.h
+++ b/bmf/hml/include/hmp/tensor.h
@@ -188,8 +188,6 @@ HMP_API Tensor from_buffer(DataPtr &&data, ScalarType scalar_type,
                            const SizeArray &shape,
                            const optional<SizeArray> &strides = nullopt);
 HMP_API Tensor empty(const SizeArray &shape, const TensorOptions &options = {});
-HMP_API Tensor empty_tensor_buffer(const int64_t &nitems,
-                                   const TensorOptions &options = {});
 HMP_API Tensor empty_like(const Tensor &other,
                           const optional<TensorOptions> &options = nullopt);
 HMP_API Tensor zeros(const SizeArray &shape, const TensorOptions &options = {});

--- a/bmf/hml/py/py_imgproc.cpp
+++ b/bmf/hml/py/py_imgproc.cpp
@@ -225,6 +225,7 @@ void imageBind(py::module &m) {
         .def("crop", &Frame::crop, py::arg("left"), py::arg("top"),
              py::arg("width"), py::arg("height"))
         .def("reformat", &Frame::reformat, py::arg("pix_info"))
+        .def("as_contiguous_storage", &Frame::as_contiguous_storage)
         .def("storage", (Tensor & (Frame::*)()) & Frame::storage)
         .def("numpy", [](const Frame &frame) {
             py::list arr_list;

--- a/bmf/hml/py/py_imgproc.cpp
+++ b/bmf/hml/py/py_imgproc.cpp
@@ -225,6 +225,7 @@ void imageBind(py::module &m) {
         .def("crop", &Frame::crop, py::arg("left"), py::arg("top"),
              py::arg("width"), py::arg("height"))
         .def("reformat", &Frame::reformat, py::arg("pix_info"))
+        .def("storage", (Tensor & (Frame::*)()) & Frame::storage)
         .def("numpy", [](const Frame &frame) {
             py::list arr_list;
             for (auto &tensor : frame.data()) {

--- a/bmf/hml/src/imgproc/image.cpp
+++ b/bmf/hml/src/imgproc/image.cpp
@@ -64,7 +64,7 @@ Frame::Frame(int width, int height, const PixelInfo &pix_info,
         nitems += TensorInfo::calcNumel(shape);
     }
 
-    storage_tensor_ = empty_tensor_buffer(nitems, options);
+    storage_tensor_ = empty({1, nitems}, options);
 
     for (int i = 0; i < pix_desc_.nplanes(); ++i) {
         SizeArray shape{pix_desc_.infer_height(height, i),

--- a/bmf/hml/src/imgproc/image.cpp
+++ b/bmf/hml/src/imgproc/image.cpp
@@ -20,8 +20,9 @@
 namespace hmp {
 
 Frame::Frame(const TensorList &data, int width, int height,
-             const PixelInfo &pix_info)
-    : pix_info_(pix_info), width_(width), height_(height) {
+             const PixelInfo &pix_info, const Tensor &storage_tensor)
+    : pix_info_(pix_info), width_(width), height_(height),
+      storage_tensor_(storage_tensor) {
     pix_desc_ = PixelFormatDesc(pix_info_.format());
 
     // convert to HWC layout if pixel format is supported
@@ -32,11 +33,13 @@ Frame::Frame(const TensorList &data, int width, int height,
     }
 }
 
-Frame::Frame(const TensorList &data, const PixelInfo &pix_info)
-    : Frame(data, data[0].size(1), data[0].size(0), pix_info) {}
+Frame::Frame(const TensorList &data, const PixelInfo &pix_info,
+             const Tensor &storage_tensor)
+    : Frame(data, data[0].size(1), data[0].size(0), pix_info, storage_tensor) {}
 
-Frame::Frame(const Tensor &data, const PixelInfo &pix_info)
-    : Frame({data}, data.size(1), data.size(0), pix_info) {}
+Frame::Frame(const Tensor &data, const PixelInfo &pix_info,
+             const Tensor &storage_tensor)
+    : Frame({data}, data.size(1), data.size(0), pix_info, storage_tensor) {}
 
 Frame::Frame(int width, int height, const PixelInfo &pix_info,
              const Device &device)
@@ -47,15 +50,40 @@ Frame::Frame(int width, int height, const PixelInfo &pix_info,
                 pix_info_.format());
 
     auto options = TensorOptions(device).dtype(pix_desc_.dtype());
+    // calculate total size of frame
+
+    int64_t nitems = 0;
+
+    SizeArray offsetArray;
+
     for (int i = 0; i < pix_desc_.nplanes(); ++i) {
         SizeArray shape{pix_desc_.infer_height(height, i),
                         pix_desc_.infer_width(width, i), pix_desc_.channels(i)};
 
-        data_.push_back(empty(shape, options));
+        offsetArray.push_back(nitems);
+        nitems += TensorInfo::calcNumel(shape);
+    }
+
+    storage_tensor_ = empty_tensor_buffer(nitems, options);
+
+    for (int i = 0; i < pix_desc_.nplanes(); ++i) {
+        SizeArray shape{pix_desc_.infer_height(height, i),
+                        pix_desc_.infer_width(width, i), pix_desc_.channels(i)};
+        auto strides = calcContiguousStrides(shape);
+        Tensor t = storage_tensor_.as_strided(shape, strides, offsetArray[i]);
+        data_.push_back(t);
     }
 }
 
 Frame Frame::to(const Device &device, bool non_blocking) const {
+    if (storage_tensor_.defined()) {
+        Tensor new_storage_tensor = storage_tensor_.to(device, non_blocking);
+        TensorList out =
+            from_storage_tensor(new_storage_tensor, data_); // change buffer
+        return Frame(out, width_, height_, pix_info_, new_storage_tensor);
+    }
+
+    //
     TensorList out;
     for (auto &d : data_) {
         out.push_back(d.to(device, non_blocking));
@@ -64,11 +92,7 @@ Frame Frame::to(const Device &device, bool non_blocking) const {
 }
 
 Frame Frame::to(DeviceType device, bool non_blocking) const {
-    TensorList out;
-    for (auto &d : data_) {
-        out.push_back(d.to(device, non_blocking));
-    }
-    return Frame(out, width_, height_, pix_info_);
+    return to(Device(device), non_blocking);
 }
 
 Frame &Frame::copy_(const Frame &from) {
@@ -82,6 +106,13 @@ Frame &Frame::copy_(const Frame &from) {
 }
 
 Frame Frame::clone() const {
+    if (storage_tensor_.defined()) {
+        Tensor new_storage_tensor = storage_tensor_.clone();
+        TensorList out =
+            from_storage_tensor(new_storage_tensor, data_); // change buffer
+        return Frame(out, width_, height_, pix_info_, new_storage_tensor);
+    }
+
     TensorList out;
     for (auto &d : data_) {
         out.push_back(d.clone());
@@ -125,7 +156,7 @@ Frame Frame::crop(int left, int top, int w, int h) const {
         out.push_back(d.slice(0, t, b).slice(1, l, r));
     }
 
-    return Frame(out, w, h, pix_info_);
+    return Frame(out, w, h, pix_info_, storage_tensor_);
 }
 
 PixelFormat format420_list[] = {PF_YUV420P, PF_NV12, PF_NV21, PF_P010LE,
@@ -140,19 +171,43 @@ static bool is_420(const PixelFormat &pix_fmt) {
 
 Frame Frame::reformat(const PixelInfo &pix_info) {
     if (pix_info_.format() == PF_RGB24 || pix_info_.format() == PF_RGB48) {
-        auto yuv = img::rgb_to_yuv(data_[0], pix_info, kNHWC);
-        return Frame(yuv, width_, height_, pix_info);
+        Frame frame(width_, height_, pix_info, device());
+        auto yuv = img::rgb_to_yuv(frame.data(), data_[0], pix_info, kNHWC);
+        return frame;
 
     } else if (pix_info.format() == PF_RGB24 || pix_info.format() == PF_RGB48) {
         auto rgb = img::yuv_to_rgb(data_, pix_info_, kNHWC);
         return Frame({rgb}, width_, height_, pix_info);
+
     } else if (is_420(pix_info.format()) && is_420(pix_info_.format())) {
-        auto yuv = img::yuv_to_yuv(data_, pix_info, pix_info_);
-        return Frame(yuv, width_, height_, pix_info);
+        Frame frame(width_, height_, pix_info, device());
+        auto yuv = img::yuv_to_yuv(frame.data(), data_, pix_info, pix_info_);
+        return frame;
     }
 
     HMP_REQUIRE(false, "{} to {} not support", stringfy(pix_info_.format()),
                 stringfy(pix_info.format()));
+}
+
+TensorList from_storage_tensor(const Tensor &storage_tensor,
+                               const TensorList &mirror) {
+    TensorList out; // change buffer
+
+    if (!storage_tensor.defined()) {
+        return out;
+    }
+
+    Buffer b = storage_tensor.tensorInfo()->buffer();
+
+    for (auto &d : mirror) {
+        auto old_ti = d.tensorInfo();
+        auto ti = makeRefPtr<TensorInfo>(b, old_ti->shape(), old_ti->strides(),
+                                         old_ti->bufferOffset());
+        Tensor t(std::move(ti));
+        out.push_back(t);
+    }
+
+    return out;
 }
 
 std::string stringfy(const Frame &frame) {

--- a/bmf/hml/src/imgproc/image.cpp
+++ b/bmf/hml/src/imgproc/image.cpp
@@ -210,6 +210,15 @@ TensorList from_storage_tensor(const Tensor &storage_tensor,
     return out;
 }
 
+Frame Frame::as_contiguous_storage() {
+    if (storage_tensor_.defined()) {
+        return *this;
+    }
+    Frame frame(width_, height_, pix_info_, device());
+    frame.copy_(*this);
+    return frame;
+}
+
 std::string stringfy(const Frame &frame) {
     return fmt::format("Frame({}, {}, {}, ({}, {}, {}))", frame.device(),
                        frame.dtype(), frame.format(), frame.nplanes(),

--- a/bmf/hml/src/kernel/tensor_factory.cpp
+++ b/bmf/hml/src/kernel/tensor_factory.cpp
@@ -42,6 +42,23 @@ Tensor empty(const SizeArray &shape, const TensorOptions &options) {
         shape));
 }
 
+Tensor empty_tensor_buffer(const int64_t &nitems,
+                           const TensorOptions &options) {
+    unsigned flags = 0;
+    if (options.pinned_memory()) {
+        flags |= static_cast<unsigned>(AllocatorFlags::Pinned);
+    }
+
+    auto scalar_type = options.scalar_type();
+    auto device_type = options.device().type();
+    auto allocator = get_allocator(device_type, flags);
+    HMP_REQUIRE(allocator, "Device type {} is not supported", device_type);
+
+    return Tensor(makeRefPtr<TensorInfo>(
+        Buffer(scalar_type, nitems, allocator, options.pinned_memory()),
+        std::vector<int64_t>(1, nitems)));
+}
+
 Tensor &copy(Tensor &self, const Tensor &other) {
 #ifndef HMP_BUILD_SHARED
     HMP_IMPORT_DEVICE_DISPATCH(kCPU, copy_stub);

--- a/bmf/hml/src/kernel/tensor_factory.cpp
+++ b/bmf/hml/src/kernel/tensor_factory.cpp
@@ -42,23 +42,6 @@ Tensor empty(const SizeArray &shape, const TensorOptions &options) {
         shape));
 }
 
-Tensor empty_tensor_buffer(const int64_t &nitems,
-                           const TensorOptions &options) {
-    unsigned flags = 0;
-    if (options.pinned_memory()) {
-        flags |= static_cast<unsigned>(AllocatorFlags::Pinned);
-    }
-
-    auto scalar_type = options.scalar_type();
-    auto device_type = options.device().type();
-    auto allocator = get_allocator(device_type, flags);
-    HMP_REQUIRE(allocator, "Device type {} is not supported", device_type);
-
-    return Tensor(makeRefPtr<TensorInfo>(
-        Buffer(scalar_type, nitems, allocator, options.pinned_memory()),
-        std::vector<int64_t>(1, nitems)));
-}
-
 Tensor &copy(Tensor &self, const Tensor &other) {
 #ifndef HMP_BUILD_SHARED
     HMP_IMPORT_DEVICE_DISPATCH(kCPU, copy_stub);

--- a/bmf/hml/src/kernel/tensor_factory.h
+++ b/bmf/hml/src/kernel/tensor_factory.h
@@ -26,6 +26,7 @@ HMP_DECLARE_DISPATCH_STUB(arange_stub,
                           Tensor &(*)(Tensor &, int64_t, int64_t, int64_t))
 
 Tensor empty(const SizeArray &shape, const TensorOptions &options);
+Tensor empty_tensor_buffer(const int64_t &nitems, const TensorOptions &options);
 Tensor &copy(Tensor &self, const Tensor &other);
 } // namespace kernel
 } // namespace hmp

--- a/bmf/hml/src/kernel/tensor_factory.h
+++ b/bmf/hml/src/kernel/tensor_factory.h
@@ -26,7 +26,6 @@ HMP_DECLARE_DISPATCH_STUB(arange_stub,
                           Tensor &(*)(Tensor &, int64_t, int64_t, int64_t))
 
 Tensor empty(const SizeArray &shape, const TensorOptions &options);
-Tensor empty_tensor_buffer(const int64_t &nitems, const TensorOptions &options);
 Tensor &copy(Tensor &self, const Tensor &other);
 } // namespace kernel
 } // namespace hmp

--- a/bmf/hml/src/tensor.cpp
+++ b/bmf/hml/src/tensor.cpp
@@ -273,6 +273,14 @@ Tensor empty(const SizeArray &shape, const TensorOptions &options) {
     return kernel::empty(shape, options);
 }
 
+Tensor empty_tensor_buffer(const int64_t &nitems,
+                           const TensorOptions &options) {
+    HMP_REQUIRE(nitems > 0, "nitems is invalid: {}", nitems);
+    DeviceGuard dguard(options.device());
+
+    return kernel::empty_tensor_buffer(nitems, options);
+}
+
 Tensor empty_like(const Tensor &other,
                   const optional<TensorOptions> &options_) {
     auto options = options_.value_or(other.options());

--- a/bmf/hml/src/tensor.cpp
+++ b/bmf/hml/src/tensor.cpp
@@ -273,14 +273,6 @@ Tensor empty(const SizeArray &shape, const TensorOptions &options) {
     return kernel::empty(shape, options);
 }
 
-Tensor empty_tensor_buffer(const int64_t &nitems,
-                           const TensorOptions &options) {
-    HMP_REQUIRE(nitems > 0, "nitems is invalid: {}", nitems);
-    DeviceGuard dguard(options.device());
-
-    return kernel::empty_tensor_buffer(nitems, options);
-}
-
 Tensor empty_like(const Tensor &other,
                   const optional<TensorOptions> &options_) {
     auto options = options_.value_or(other.options());

--- a/bmf/python/py_module_sdk.cpp
+++ b/bmf/python/py_module_sdk.cpp
@@ -385,7 +385,8 @@ void module_sdk_bind(py::module &m) {
              py::arg("device"), py::arg("non_blocking") = false)
         .def("copy_props", &VideoFrame::copy_props, py::arg("from"),
              py::arg("copy_private") = false)
-        .def("reformat", &VideoFrame::reformat, py::arg("pix_info"));
+        .def("reformat", &VideoFrame::reformat, py::arg("pix_info"))
+        .def("as_contiguous_storage", &VideoFrame::as_contiguous_storage);
     PACKET_REGISTER_BMF_SDK_TYPE(VideoFrame)
 
     // AudioFrame

--- a/bmf/sdk/cpp_sdk/include/bmf/sdk/video_frame.h
+++ b/bmf/sdk/cpp_sdk/include/bmf/sdk/video_frame.h
@@ -189,6 +189,14 @@ class BMF_API VideoFrame : public OpaqueDataSet,
      */
     VideoFrame &copy_props(const VideoFrame &from, bool copy_private = false);
 
+    /**
+     * @brief frame with multiple planes are stored in contiguous memory
+     *
+     * @param
+     * @return VideoFrame
+     */
+    VideoFrame as_contiguous_storage();
+
   protected:
     VideoFrame(const std::shared_ptr<Private> &other);
 

--- a/bmf/sdk/cpp_sdk/src/video_frame.cpp
+++ b/bmf/sdk/cpp_sdk/src/video_frame.cpp
@@ -107,4 +107,12 @@ VideoFrame VideoFrame::reformat(const PixelInfo &pix_info) {
     return VideoFrame(frame);
 }
 
+VideoFrame VideoFrame::as_contiguous_storage() {
+    VideoFrame vf;
+    auto frame = self->frame.as_contiguous_storage();
+    vf = VideoFrame(frame);
+    vf.SequenceData::copy_props(*this);
+    return vf;
+}
+
 } // namespace bmf_sdk

--- a/bmf/sdk/cpp_sdk/test/test_video_frame.cpp
+++ b/bmf/sdk/cpp_sdk/test/test_video_frame.cpp
@@ -507,7 +507,7 @@ TEST(video_frame, check_continue) {
     int height = 1080;
     auto H420 = PixelInfo(hmp::PF_YUV420P, hmp::CS_BT709);
     auto vf = VideoFrame::make(width, height, H420, Device(kCUDA, 0)); //
-    EXPECT_EQ(hmp::ffmpeg::check_cuda_frame_need_copy_for_ffmpeg(vf.frame()),
+    EXPECT_EQ(hmp::ffmpeg::check_frame_memory_is_contiguous(vf.frame()),
               false);
 }
 
@@ -524,7 +524,7 @@ TEST(video_frame, copy_frame_test) {
     {
         for (int i = 0; i < count; ++i) {
             auto cudaframe = vf[i].cuda();
-            EXPECT_EQ(hmp::ffmpeg::check_cuda_frame_need_copy_for_ffmpeg(
+            EXPECT_EQ(hmp::ffmpeg::check_frame_memory_is_contiguous(
                           cudaframe.frame()),
                       false);
         }

--- a/bmf/test/cuda_frame_encode/copy_frame.py
+++ b/bmf/test/cuda_frame_encode/copy_frame.py
@@ -29,11 +29,12 @@ class copy_frame(Module):
             frame = pkt.get(VideoFrame)
             width = frame.width
             height = frame.height
-            video_frame = VideoFrame(width,
-                                     height,
-                                     mp.PixelInfo(mp.kPF_NV12),
-                                     device="cuda")
-            video_frame.copy_(frame)
+            #video_frame = VideoFrame(width,
+            #                         height,
+            #                         mp.PixelInfo(mp.kPF_NV12),
+            #                         device="cuda")
+            #video_frame.copy_(frame)
+            video_frame = frame.as_contiguous_storage()
             video_frame.time_base = frame.time_base
             video_frame.pts = frame.pts
             pkt = Packet(video_frame)

--- a/bmf/test/cuda_frame_encode/copy_frame.py
+++ b/bmf/test/cuda_frame_encode/copy_frame.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from bmf import Module, Log, LogLevel, InputType, ProcessResult, Packet, Timestamp, scale_av_pts, av_time_base, VideoFrame
+
+from bmf.lib._bmf.sdk import Rational
+import bmf.hml.hmp as mp
+
+
+class copy_frame(Module):
+
+    def __init__(self, node, option=None):
+        self.node_ = node
+
+    def process(self, task):
+        output_packets = task.get_outputs()[0]
+        input_packets = task.get_inputs()[0]
+
+        while not input_packets.empty():
+            pkt = input_packets.get()
+
+            # process EOS
+            if pkt.timestamp == Timestamp.EOF:
+                Log.log_node(LogLevel.DEBUG, task.get_node(), "Receive EOF")
+                output_packets.put(Packet.generate_eof_packet())
+                task.timestamp = Timestamp.DONE
+                return ProcessResult.OK
+
+            frame = pkt.get(VideoFrame)
+            width = frame.width
+            height = frame.height
+            video_frame = VideoFrame(width,
+                                     height,
+                                     mp.PixelInfo(mp.kPF_NV12),
+                                     device="cuda")
+            video_frame.copy_(frame)
+            video_frame.time_base = frame.time_base
+            video_frame.pts = frame.pts
+            pkt = Packet(video_frame)
+            pkt.timestamp = video_frame.pts
+            output_packets.put(pkt)
+
+        return ProcessResult.OK

--- a/bmf/test/cuda_frame_encode/test_copy_transcode.py
+++ b/bmf/test/cuda_frame_encode/test_copy_transcode.py
@@ -1,0 +1,46 @@
+import bmf
+from bmf import VideoFrame
+
+import subprocess
+
+input_path = "../../files/big_bunny_10s_30fps.mp4"
+output_path = "output.mp4"
+
+
+def check_psnr(input_file, output_file):
+    cmd = 'ffmpeg  -i {} -i {} -lavfi "psnr" -f null - 2>&1 | grep Parsed_psnr'.format(
+        input_path, output_path)
+    psnr_text = subprocess.check_output(cmd, shell=True, text=True)
+    print(psnr_text)
+    for text in psnr_text.split():
+        if text.startswith("min"):
+            _, min_psnr = text.split(":")
+            if float(min_psnr) < 40:
+                raise Exception("psnr check failed")
+
+
+def test_trans():
+    bmf.graph().decode({
+        'input_path': input_path,
+        'video_params': {
+            'hwaccel': 'cuda',
+        },
+    })['video'].module("copy_frame",
+                       None,
+                       entry="copy_frame.copy_frame",
+                       input_manager="immediate").encode(
+                           None, {
+                               "video_params": {
+                                   "codec": "h264_nvenc",
+                                   "pix_fmt": "cuda",
+                                   "vsync": "vfr",
+                                   "max_fr": 30,
+                               },
+                               "output_path": output_path,
+                           }).run()
+
+    check_psnr(input_path, output_path)
+
+
+if __name__ == "__main__":
+    test_trans()


### PR DESCRIPTION
包含多个plane的hmp::Frame内部使用一个连续的buffer用来存储多个plane tensor. 这个buffer通过storage_tensor这个tensor来管理，可以通过storage_tensor的h2d，d2h操作达到整个hmp::Frame的h2d/d2h目的。
同时保留对hmp::Frame接口的兼容，修改部分接口实现。