### PR TITLE
Hotfix/update transcode colab

### DIFF
--- a/bmf/demo/transcode/bmf_transcode_demo.ipynb
+++ b/bmf/demo/transcode/bmf_transcode_demo.ipynb
@@ -4,7 +4,8 @@
   "metadata": {
     "colab": {
       "provenance": [],
-      "toc_visible": true
+      "toc_visible": true,
+      "private_outputs": true
     },
     "kernelspec": {
       "name": "python3",
@@ -47,47 +48,13 @@
     {
       "cell_type": "code",
       "source": [
-        "! apt show ffmpeg libavcodec-dev libavdevice-dev libavfilter-dev libavformat-dev libavresample-dev libavutil-dev libpostproc-dev libswresample-dev libswscale-dev | grep \"^Package:\\|^Version:\""
+        "! apt show ffmpeg | grep \"^Package:\\|^Version:\""
       ],
       "metadata": {
-        "id": "JRc_qwCp7lKQ",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "4ed1e49e-b39a-40dc-aad1-63f331f0e506"
+        "id": "JRc_qwCp7lKQ"
       },
-      "execution_count": 12,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "\n",
-            "WARNING: apt does not have a stable CLI interface. Use with caution in scripts.\n",
-            "\n",
-            "Package: ffmpeg\n",
-            "Version: 7:4.2.7-0ubuntu0.1\n",
-            "Package: libavcodec-dev\n",
-            "Version: 7:4.2.7-0ubuntu0.1\n",
-            "Package: libavdevice-dev\n",
-            "Version: 7:4.2.7-0ubuntu0.1\n",
-            "Package: libavfilter-dev\n",
-            "Version: 7:4.2.7-0ubuntu0.1\n",
-            "Package: libavformat-dev\n",
-            "Version: 7:4.2.7-0ubuntu0.1\n",
-            "Package: libavresample-dev\n",
-            "Version: 7:4.2.7-0ubuntu0.1\n",
-            "Package: libavutil-dev\n",
-            "Version: 7:4.2.7-0ubuntu0.1\n",
-            "Package: libpostproc-dev\n",
-            "Version: 7:4.2.7-0ubuntu0.1\n",
-            "Package: libswresample-dev\n",
-            "Version: 7:4.2.7-0ubuntu0.1\n",
-            "Package: libswscale-dev\n",
-            "Version: 7:4.2.7-0ubuntu0.1\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -101,38 +68,13 @@
     {
       "cell_type": "code",
       "source": [
-        "! apt install -y ffmpeg libavcodec-dev libavdevice-dev libavfilter-dev libavformat-dev libavresample-dev libavutil-dev libpostproc-dev libswresample-dev libswscale-dev"
+        "! apt install -y ffmpeg"
       ],
       "metadata": {
-        "id": "P2HXgryJ8WM1",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "63f0f0dc-c303-4dad-8c5f-1e43450bcce7"
+        "id": "P2HXgryJ8WM1"
       },
-      "execution_count": 13,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Reading package lists... Done\n",
-            "Building dependency tree       \n",
-            "Reading state information... Done\n",
-            "ffmpeg is already the newest version (7:4.2.7-0ubuntu0.1).\n",
-            "libavcodec-dev is already the newest version (7:4.2.7-0ubuntu0.1).\n",
-            "libavdevice-dev is already the newest version (7:4.2.7-0ubuntu0.1).\n",
-            "libavfilter-dev is already the newest version (7:4.2.7-0ubuntu0.1).\n",
-            "libavformat-dev is already the newest version (7:4.2.7-0ubuntu0.1).\n",
-            "libavresample-dev is already the newest version (7:4.2.7-0ubuntu0.1).\n",
-            "libavutil-dev is already the newest version (7:4.2.7-0ubuntu0.1).\n",
-            "libpostproc-dev is already the newest version (7:4.2.7-0ubuntu0.1).\n",
-            "libswresample-dev is already the newest version (7:4.2.7-0ubuntu0.1).\n",
-            "libswscale-dev is already the newest version (7:4.2.7-0ubuntu0.1).\n",
-            "0 upgraded, 0 newly installed, 0 to remove and 15 not upgraded.\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -147,8 +89,7 @@
       "cell_type": "code",
       "source": [
         "! git clone https://github.com/BabitMF/bmf bmf\n",
-        "! cd bmf\n",
-        "! ./scripts/build_ffmpeg.sh x264 x265"
+        "! ./bmf/scripts/build_ffmpeg.sh nasm yasm x264 x265"
       ],
       "metadata": {
         "id": "Fd_ig_h-DRqo"
@@ -172,23 +113,10 @@
         "! pip3 install BabitMF"
       ],
       "metadata": {
-        "id": "nifZsafGEtAU",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "f74ccc8a-c261-41c4-cccb-2a86b6b7eced"
+        "id": "nifZsafGEtAU"
       },
-      "execution_count": 14,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Requirement already satisfied: BabitMF in /usr/local/lib/python3.10/dist-packages (0.0.5)\n",
-            "Requirement already satisfied: numpy>=1.19.5 in /usr/local/lib/python3.10/dist-packages (from BabitMF) (1.22.4)\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -207,24 +135,10 @@
         "%load_ext wurlitzer"
       ],
       "metadata": {
-        "id": "SGUtzAwyo0A3",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "a03593e7-a3f1-4fa0-cc14-6e93d086df62"
+        "id": "SGUtzAwyo0A3"
       },
-      "execution_count": 15,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Requirement already satisfied: wurlitzer in /usr/local/lib/python3.10/dist-packages (3.0.3)\n",
-            "The wurlitzer extension is already loaded. To reload it, use:\n",
-            "  %reload_ext wurlitzer\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -250,25 +164,10 @@
         "!gdown --fuzzy https://drive.google.com/file/d/1l8bDSrWn6643aDhyaocVStXdoUbVC3o2/view?usp=sharing -O big_bunny_10s_30fps.mp4"
       ],
       "metadata": {
-        "id": "nvxgOt8upwVO",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "f1ef9a73-e037-4243-bac8-0241c69c77bf"
+        "id": "nvxgOt8upwVO"
       },
-      "execution_count": 16,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Downloading...\n",
-            "From: https://drive.google.com/uc?id=1l8bDSrWn6643aDhyaocVStXdoUbVC3o2\n",
-            "To: /content/big_bunny_10s_30fps.mp4\n",
-            "\r  0% 0.00/2.56M [00:00<?, ?B/s]\r100% 2.56M/2.56M [00:00<00:00, 141MB/s]\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -276,46 +175,10 @@
         "! ffprobe big_bunny_10s_30fps.mp4"
       ],
       "metadata": {
-        "id": "4nnPCG_DuYA4",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "da68f357-8889-4caf-af7e-e8bccd581865"
+        "id": "4nnPCG_DuYA4"
       },
-      "execution_count": 17,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "ffprobe version 4.2.7-0ubuntu0.1 Copyright (c) 2007-2022 the FFmpeg developers\n",
-            "  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)\n",
-            "  configuration: --prefix=/usr --extra-version=0ubuntu0.1 --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu --incdir=/usr/include/x86_64-linux-gnu --arch=amd64 --enable-gpl --disable-stripping --enable-avresample --disable-filter=resample --enable-avisynth --enable-gnutls --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libjack --enable-libmp3lame --enable-libmysofa --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse --enable-librsvg --enable-librubberband --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libssh --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwavpack --enable-libwebp --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzmq --enable-libzvbi --enable-lv2 --enable-omx --enable-openal --enable-opencl --enable-opengl --enable-sdl2 --enable-libdc1394 --enable-libdrm --enable-libiec61883 --enable-nvenc --enable-chromaprint --enable-frei0r --enable-libx264 --enable-shared\n",
-            "  libavutil      56. 31.100 / 56. 31.100\n",
-            "  libavcodec     58. 54.100 / 58. 54.100\n",
-            "  libavformat    58. 29.100 / 58. 29.100\n",
-            "  libavdevice    58.  8.100 / 58.  8.100\n",
-            "  libavfilter     7. 57.100 /  7. 57.100\n",
-            "  libavresample   4.  0.  0 /  4.  0.  0\n",
-            "  libswscale      5.  5.100 /  5.  5.100\n",
-            "  libswresample   3.  5.100 /  3.  5.100\n",
-            "  libpostproc    55.  5.100 / 55.  5.100\n",
-            "Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'big_bunny_10s_30fps.mp4':\n",
-            "  Metadata:\n",
-            "    major_brand     : isom\n",
-            "    minor_version   : 512\n",
-            "    compatible_brands: isomiso2avc1mp41\n",
-            "    encoder         : Lavf58.76.100\n",
-            "  Duration: 00:00:10.00, start: 0.000000, bitrate: 2044 kb/s\n",
-            "    Stream #0:0(und): Video: h264 (High) (avc1 / 0x31637661), yuv420p, 1920x1080 [SAR 1:1 DAR 16:9], 1904 kb/s, 30 fps, 30 tbr, 15360 tbn, 60 tbc (default)\n",
-            "    Metadata:\n",
-            "      handler_name    : VideoHandler\n",
-            "    Stream #0:1(und): Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 129 kb/s (default)\n",
-            "    Metadata:\n",
-            "      handler_name    : SoundHandler\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -371,187 +234,10 @@
         ")"
       ],
       "metadata": {
-        "id": "6aqHpwuyWHDW",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "0d33b679-59c6-47e4-ddee-0319725cf563"
+        "id": "6aqHpwuyWHDW"
       },
-      "execution_count": 18,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "{\n",
-            "    \"input_streams\": [],\n",
-            "    \"output_streams\": [],\n",
-            "    \"nodes\": [\n",
-            "        {\n",
-            "            \"module_info\": {\n",
-            "                \"name\": \"c_ffmpeg_decoder\",\n",
-            "                \"type\": \"\",\n",
-            "                \"path\": \"\",\n",
-            "                \"entry\": \"\"\n",
-            "            },\n",
-            "            \"meta_info\": {\n",
-            "                \"premodule_id\": -1,\n",
-            "                \"callback_binding\": []\n",
-            "            },\n",
-            "            \"option\": {\n",
-            "                \"input_path\": \"./big_bunny_10s_30fps.mp4\",\n",
-            "                \"video_codec\": \"copy\",\n",
-            "                \"audio_codec\": \"copy\"\n",
-            "            },\n",
-            "            \"input_streams\": [],\n",
-            "            \"output_streams\": [\n",
-            "                {\n",
-            "                    \"identifier\": \"video:c_ffmpeg_decoder_14_1\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                },\n",
-            "                {\n",
-            "                    \"identifier\": \"audio:c_ffmpeg_decoder_14_2\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                }\n",
-            "            ],\n",
-            "            \"input_manager\": \"immediate\",\n",
-            "            \"scheduler\": 0,\n",
-            "            \"alias\": \"\",\n",
-            "            \"id\": 14\n",
-            "        },\n",
-            "        {\n",
-            "            \"module_info\": {\n",
-            "                \"name\": \"c_ffmpeg_encoder\",\n",
-            "                \"type\": \"\",\n",
-            "                \"path\": \"\",\n",
-            "                \"entry\": \"\"\n",
-            "            },\n",
-            "            \"meta_info\": {\n",
-            "                \"premodule_id\": -1,\n",
-            "                \"callback_binding\": []\n",
-            "            },\n",
-            "            \"option\": {\n",
-            "                \"output_path\": \"./remux_output.m3u8\",\n",
-            "                \"format\": \"hls\",\n",
-            "                \"mux_params\": {\n",
-            "                    \"hls_list_size\": \"0\",\n",
-            "                    \"hls_time\": \"2\",\n",
-            "                    \"hls_segment_filename\": \"./file%03d.ts\"\n",
-            "                }\n",
-            "            },\n",
-            "            \"input_streams\": [\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_decoder_14_1\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                },\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_decoder_14_2\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                }\n",
-            "            ],\n",
-            "            \"output_streams\": [],\n",
-            "            \"input_manager\": \"immediate\",\n",
-            "            \"scheduler\": 1,\n",
-            "            \"alias\": \"\",\n",
-            "            \"id\": 15\n",
-            "        }\n",
-            "    ],\n",
-            "    \"option\": {},\n",
-            "    \"mode\": \"Normal\"\n",
-            "}\n",
-            "[2023-07-11 08:03:20.368] [info] Constructing c++ module\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Input #0, mov,mp4,m4a,3gp,3g2,mj2, from './big_bunny_10s_30fps.mp4':\n",
-            "  Metadata:\n",
-            "    major_brand     : isom\n",
-            "    minor_version   : 512\n",
-            "    compatible_brands: isomiso2avc1mp41\n",
-            "    encoder         : Lavf58.76.100\n",
-            "  Duration: 00:00:10.00, start: 0.000000, bitrate: 2044 kb/s\n",
-            "    Stream #0:0(und): Video: h264 (High) (avc1 / 0x31637661), yuv420p, 1920x1080 [SAR 1:1 DAR 16:9], 1904 kb/s, 30 fps, 30 tbr, 15360 tbn, 60 tbc (default)"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "[2023-07-11 08:03:20.395] [info] c++ module constructed\n",
-            "[2023-07-11 08:03:20.396] [info] Constructing c++ module\n",
-            "[2023-07-11 08:03:20.396] [info] c++ module constructed\n",
-            "[2023-07-11 08:03:20.396] [info] BMF Version: 0.0.5\n",
-            "[2023-07-11 08:03:20.396] [info] BMF Commit: 98e17ef\n",
-            "[2023-07-11 08:03:20.396] [info] start init graph\n",
-            "[2023-07-11 08:03:20.396] [info] scheduler count2\n",
-            "debug queue size, node 14, queue size: 5\n",
-            "[2023-07-11 08:03:20.396] [info] node:c_ffmpeg_decoder 14 scheduler 0\n",
-            "debug queue size, node 15, queue size: 5\n",
-            "[2023-07-11 08:03:20.396] [info] node:c_ffmpeg_encoder 15 scheduler 1\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "\n",
-            "    Metadata:\n",
-            "      handler_name    : VideoHandler\n",
-            "    Stream #0:1(und): Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 129 kb/s (default)\n",
-            "    Metadata:\n",
-            "      handler_name    : SoundHandler\n",
-            "[hls @ 0x7f36001c0480] Opening './file000.ts' for writing\n",
-            "Output #0, hls, to './remux_output.m3u8':\n",
-            "  Metadata:\n",
-            "    encoder         : Lavf58.29.100\n",
-            "    Stream #0:0: Video: h264 (High) (avc1 / 0x31637661), yuv420p, 1920x1080 [SAR 1:1 DAR 16:9], q=2-31, 1904 kb/s, 30 fps, 30 tbr, 90k tbn, 15360 tbc\n",
-            "    Stream #0:1: Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 129 kb/s\n",
-            "[hls @ 0x7f36001c0480] Opening './remux_output.m3u8.tmp' for writing\n",
-            "[hls @ 0x7f36001c0480] Opening './file001.ts' for writing\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "[2023-07-11 08:03:20.485] [info] node id:14 decode flushing\n",
-            "[2023-07-11 08:03:20.485] [info] node id:14 Process node end\n",
-            "[2023-07-11 08:03:20.486] [info] node id:14 close node\n",
-            "[2023-07-11 08:03:20.486] [info] node 14 close report, closed count: 1\n",
-            "[2023-07-11 08:03:20.486] [info] node id:15 eof received\n",
-            "[2023-07-11 08:03:20.486] [info] node id:15 eof processed, remove node from scheduler\n",
-            "[2023-07-11 08:03:20.486] [info] node id:15 eof received\n",
-            "[2023-07-11 08:03:20.486] [info] node id:15 eof processed, remove node from scheduler\n",
-            "[2023-07-11 08:03:20.486] [info] node id:15 process eof, add node to scheduler\n",
-            "[2023-07-11 08:03:20.487] [info] node id:15 Process node end\n",
-            "[2023-07-11 08:03:20.487] [info] node id:15 close node\n",
-            "[2023-07-11 08:03:20.487] [info] node 15 close report, closed count: 2\n",
-            "[2023-07-11 08:03:20.487] [info] schedule queue 0 start to join thread\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[hls @ 0x7f36001c0480] Opening './remux_output.m3u8.tmp' for writing\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "[2023-07-11 08:03:20.487] [info] schedule queue 0 thread quit\n",
-            "[2023-07-11 08:03:20.487] [info] schedule queue 0 closed\n",
-            "[2023-07-11 08:03:20.487] [info] schedule queue 1 start to join thread\n",
-            "[2023-07-11 08:03:20.487] [info] schedule queue 1 thread quit\n",
-            "[2023-07-11 08:03:20.488] [info] schedule queue 1 closed\n",
-            "[2023-07-11 08:03:20.488] [info] all scheduling threads were joint\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -560,46 +246,10 @@
         "! rm -rf remux_output.m3u8 file*.ts"
       ],
       "metadata": {
-        "id": "yCgv91CmzgJg",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "489ba968-e00b-4adf-833d-79de3c951a80"
+        "id": "yCgv91CmzgJg"
       },
-      "execution_count": 19,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "ffprobe version 4.2.7-0ubuntu0.1 Copyright (c) 2007-2022 the FFmpeg developers\n",
-            "  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)\n",
-            "  configuration: --prefix=/usr --extra-version=0ubuntu0.1 --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu --incdir=/usr/include/x86_64-linux-gnu --arch=amd64 --enable-gpl --disable-stripping --enable-avresample --disable-filter=resample --enable-avisynth --enable-gnutls --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libjack --enable-libmp3lame --enable-libmysofa --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse --enable-librsvg --enable-librubberband --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libssh --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwavpack --enable-libwebp --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzmq --enable-libzvbi --enable-lv2 --enable-omx --enable-openal --enable-opencl --enable-opengl --enable-sdl2 --enable-libdc1394 --enable-libdrm --enable-libiec61883 --enable-nvenc --enable-chromaprint --enable-frei0r --enable-libx264 --enable-shared\n",
-            "  libavutil      56. 31.100 / 56. 31.100\n",
-            "  libavcodec     58. 54.100 / 58. 54.100\n",
-            "  libavformat    58. 29.100 / 58. 29.100\n",
-            "  libavdevice    58.  8.100 / 58.  8.100\n",
-            "  libavfilter     7. 57.100 /  7. 57.100\n",
-            "  libavresample   4.  0.  0 /  4.  0.  0\n",
-            "  libswscale      5.  5.100 /  5.  5.100\n",
-            "  libswresample   3.  5.100 /  3.  5.100\n",
-            "  libpostproc    55.  5.100 / 55.  5.100\n",
-            "\u001b[0;35m[hls @ 0x558d359de5c0] \u001b[0mSkip ('#EXT-X-VERSION:3')\n",
-            "\u001b[0;35m[hls @ 0x558d359de5c0] \u001b[0mOpening 'file000.ts' for reading\n",
-            "Input #0, hls, from 'remux_output.m3u8':\n",
-            "  Duration: 00:00:10.00, start: 0.043444, bitrate: 0 kb/s\n",
-            "  Program 0 \n",
-            "    Metadata:\n",
-            "      variant_bitrate : 0\n",
-            "    Stream #0:0: Video: h264 (High) ([27][0][0][0] / 0x001B), yuv420p, 1920x1080 [SAR 1:1 DAR 16:9], 30 fps, 30 tbr, 90k tbn, 60 tbc\n",
-            "    Metadata:\n",
-            "      variant_bitrate : 0\n",
-            "    Stream #0:1: Audio: aac (LC) ([15][0][0][0] / 0x000F), 44100 Hz, stereo, fltp\n",
-            "    Metadata:\n",
-            "      variant_bitrate : 0\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -631,242 +281,10 @@
         ")"
       ],
       "metadata": {
-        "id": "P94Vb09JvN-G",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "19921425-cd9a-41c7-92d6-b583f1118ecc"
+        "id": "P94Vb09JvN-G"
       },
-      "execution_count": 20,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "{\n",
-            "    \"input_streams\": [],\n",
-            "    \"output_streams\": [],\n",
-            "    \"nodes\": [\n",
-            "        {\n",
-            "            \"module_info\": {\n",
-            "                \"name\": \"c_ffmpeg_decoder\",\n",
-            "                \"type\": \"\",\n",
-            "                \"path\": \"\",\n",
-            "                \"entry\": \"\"\n",
-            "            },\n",
-            "            \"meta_info\": {\n",
-            "                \"premodule_id\": -1,\n",
-            "                \"callback_binding\": []\n",
-            "            },\n",
-            "            \"option\": {\n",
-            "                \"input_path\": \"./big_bunny_10s_30fps.mp4\"\n",
-            "            },\n",
-            "            \"input_streams\": [],\n",
-            "            \"output_streams\": [\n",
-            "                {\n",
-            "                    \"identifier\": \"video:c_ffmpeg_decoder_16_1\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                }\n",
-            "            ],\n",
-            "            \"input_manager\": \"immediate\",\n",
-            "            \"scheduler\": 0,\n",
-            "            \"alias\": \"\",\n",
-            "            \"id\": 16\n",
-            "        },\n",
-            "        {\n",
-            "            \"module_info\": {\n",
-            "                \"name\": \"c_ffmpeg_filter\",\n",
-            "                \"type\": \"\",\n",
-            "                \"path\": \"\",\n",
-            "                \"entry\": \"\"\n",
-            "            },\n",
-            "            \"meta_info\": {\n",
-            "                \"premodule_id\": -1,\n",
-            "                \"callback_binding\": []\n",
-            "            },\n",
-            "            \"option\": {\n",
-            "                \"name\": \"scale\",\n",
-            "                \"para\": \"720:576\"\n",
-            "            },\n",
-            "            \"input_streams\": [\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_decoder_16_1\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                }\n",
-            "            ],\n",
-            "            \"output_streams\": [\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_filter_17_0\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                }\n",
-            "            ],\n",
-            "            \"input_manager\": \"immediate\",\n",
-            "            \"scheduler\": 0,\n",
-            "            \"alias\": \"\",\n",
-            "            \"id\": 17\n",
-            "        },\n",
-            "        {\n",
-            "            \"module_info\": {\n",
-            "                \"name\": \"c_ffmpeg_encoder\",\n",
-            "                \"type\": \"\",\n",
-            "                \"path\": \"\",\n",
-            "                \"entry\": \"\"\n",
-            "            },\n",
-            "            \"meta_info\": {\n",
-            "                \"premodule_id\": -1,\n",
-            "                \"callback_binding\": []\n",
-            "            },\n",
-            "            \"option\": {\n",
-            "                \"output_path\": \"./decode_scale_encode_output.mp4\",\n",
-            "                \"video_params\": {\n",
-            "                    \"codec\": \"libx265\"\n",
-            "                }\n",
-            "            },\n",
-            "            \"input_streams\": [\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_filter_17_0\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                }\n",
-            "            ],\n",
-            "            \"output_streams\": [],\n",
-            "            \"input_manager\": \"immediate\",\n",
-            "            \"scheduler\": 1,\n",
-            "            \"alias\": \"\",\n",
-            "            \"id\": 18\n",
-            "        }\n",
-            "    ],\n",
-            "    \"option\": {},\n",
-            "    \"mode\": \"Normal\"\n",
-            "}\n",
-            "[2023-07-11 08:04:23.669] [info] Constructing c++ module\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Input #0, mov,mp4,m4a,3gp,3g2,mj2, from './big_bunny_10s_30fps.mp4':\n",
-            "  Metadata:\n",
-            "    major_brand     : isom\n",
-            "    minor_version   : 512\n",
-            "    compatible_brands: isomiso2avc1mp41\n",
-            "    encoder         : Lavf58.76.100\n",
-            "  Duration: 00:00:10.00, start: 0.000000, bitrate: 2044 kb/s\n",
-            "    Stream #0:0(und): Video: h264 (High) (avc1 / 0x31637661), yuv420p, 1920x1080 [SAR 1:1 DAR 16:9], 1904 kb/s, 30 fps, 30 tbr, 15360 tbn, 60 tbc (default)\n",
-            "    Metadata:\n",
-            "      handler_name    : VideoHandler\n",
-            "    Stream #0:1(und): Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 129 kb/s (default)\n",
-            "    Metadata:\n",
-            "      handler_name    : SoundHandler\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "[2023-07-11 08:04:23.686] [info] c++ module constructed\n",
-            "[2023-07-11 08:04:23.686] [info] Constructing c++ module\n",
-            "[2023-07-11 08:04:23.686] [info] c++ module constructed\n",
-            "[2023-07-11 08:04:23.686] [info] Constructing c++ module\n",
-            "[2023-07-11 08:04:23.686] [info] c++ module constructed\n",
-            "[2023-07-11 08:04:23.694] [info] BMF Version: 0.0.5\n",
-            "[2023-07-11 08:04:23.694] [info] BMF Commit: 98e17ef\n",
-            "[2023-07-11 08:04:23.694] [info] start init graph\n",
-            "[2023-07-11 08:04:23.699] [info] scheduler count2\n",
-            "debug queue size, node 16, queue size: 5\n",
-            "[2023-07-11 08:04:23.699] [info] node:c_ffmpeg_decoder 16 scheduler 0\n",
-            "debug queue size, node 18, queue size: 5\n",
-            "[2023-07-11 08:04:23.699] [info] node:c_ffmpeg_encoder 18 scheduler 1\n",
-            "debug queue size, node 17, queue size: 5\n",
-            "[2023-07-11 08:04:23.699] [info] Constructing c++ module\n",
-            "[2023-07-11 08:04:23.699] [info] c++ module constructed\n",
-            "[2023-07-11 08:04:23.699] [info] node:c_ffmpeg_filter 17 scheduler 0\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "x265 [info]: HEVC encoder version 3.2.1+1-b5c86a64bbbe\n",
-            "x265 [info]: build info [Linux][GCC 9.3.0][64 bit] 8bit+10bit+12bit\n",
-            "x265 [info]: using cpu capabilities: MMX2 SSE2Fast LZCNT SSSE3 SSE4.2 AVX FMA3 BMI2 AVX2\n",
-            "x265 [info]: Main profile, Level-3 (Main tier)\n",
-            "x265 [info]: Thread pool created using 2 threads\n",
-            "x265 [info]: Slices                              : 1\n",
-            "x265 [info]: frame threads / pool features       : 1 / wpp(9 rows)\n",
-            "x265 [warning]: Source height < 720p; disabling lookahead-slices\n",
-            "set_mempolicy: Operation not permitted\n",
-            "set_mempolicy: Operation not permitted\n",
-            "set_mempolicy: Operation not permitted\n",
-            "set_mempolicy: Operation not permitted\n",
-            "set_mempolicy: Operation not permitted\n",
-            "set_mempolicy: Operation not permitted\n",
-            "x265 [info]: Coding QT: max CU size, min CU size : 64 / 8\n",
-            "x265 [info]: Residual QT: max TU size, max depth : 32 / 1 inter / 1 intra\n",
-            "x265 [info]: ME / range / subpel / merge         : hex / 57 / 2 / 3\n",
-            "x265 [info]: Keyframe min / max / scenecut / bias: 25 / 250 / 40 / 5.00\n",
-            "x265 [info]: Lookahead / bframes / badapt        : 20 / 4 / 2\n",
-            "x265 [info]: b-pyramid / weightp / weightb       : 1 / 1 / 0\n",
-            "x265 [info]: References / ref-limit  cu / depth  : 3 / off / on\n",
-            "x265 [info]: AQ: mode / str / qg-size / cu-tree  : 2 / 1.0 / 32 / 1\n",
-            "x265 [info]: Rate Control / qCompress            : CRF-28.0 / 0.60\n",
-            "x265 [info]: tools: rd=3 psy-rd=2.00 early-skip rskip signhide tmvp b-intra\n",
-            "x265 [info]: tools: strong-intra-smoothing deblock sao\n",
-            "Output #0, mp4, to './decode_scale_encode_output.mp4':\n",
-            "  Metadata:\n",
-            "    encoder         : Lavf58.29.100\n",
-            "    Stream #0:0: Video: hevc (hev1 / 0x31766568), yuv420p, 720x576 [SAR 64:45 DAR 16:9], q=2-31, 30 fps, 30 tbr, 15360 tbn, 30 tbc\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "[2023-07-11 08:04:33.837] [info] node id:16 decode flushing\n",
-            "[2023-07-11 08:04:33.837] [info] node id:16 Process node end\n",
-            "[2023-07-11 08:04:33.842] [info] node id:16 close node\n",
-            "[2023-07-11 08:04:33.842] [info] node 16 close report, closed count: 1\n",
-            "[2023-07-11 08:04:33.842] [info] node id:17 eof received\n",
-            "[2023-07-11 08:04:34.270] [info] node id:17 eof processed, remove node from scheduler\n",
-            "[2023-07-11 08:04:34.271] [info] node id:17 process eof, add node to scheduler\n",
-            "[2023-07-11 08:04:34.304] [info] node id:17 Process node end\n",
-            "[2023-07-11 08:04:34.308] [info] node id:17 close node\n",
-            "[2023-07-11 08:04:34.311] [info] node 17 close report, closed count: 2\n",
-            "[2023-07-11 08:04:34.314] [info] node id:18 eof received\n",
-            "[2023-07-11 08:04:34.314] [info] node id:18 eof processed, remove node from scheduler\n",
-            "[2023-07-11 08:04:35.205] [info] node id:18 process eof, add node to scheduler\n",
-            "[2023-07-11 08:04:35.920] [info] node id:18 Process node end\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "x265 [info]: frame I:      3, Avg QP:31.10  kb/s: 163.76  \n",
-            "x265 [info]: frame P:     74, Avg QP:31.45  kb/s: 570.11  \n",
-            "x265 [info]: frame B:    223, Avg QP:35.46  kb/s: 20.94   \n",
-            "x265 [info]: Weighted P-Frames: Y:17.6% UV:17.6%\n",
-            "x265 [info]: consecutive B-frames: 9.1% 3.9% 6.5% 49.4% 31.2% \n",
-            "\n",
-            "encoded 300 frames in 12.13s (24.73 fps), 157.83 kb/s, Avg QP:34.42\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "[2023-07-11 08:04:35.921] [info] node id:18 close node\n",
-            "[2023-07-11 08:04:35.921] [info] node 18 close report, closed count: 3\n",
-            "[2023-07-11 08:04:35.921] [info] schedule queue 0 start to join thread\n",
-            "[2023-07-11 08:04:35.921] [info] schedule queue 0 thread quit\n",
-            "[2023-07-11 08:04:35.922] [info] schedule queue 0 closed\n",
-            "[2023-07-11 08:04:35.922] [info] schedule queue 1 start to join thread\n",
-            "[2023-07-11 08:04:35.922] [info] schedule queue 1 thread quit\n",
-            "[2023-07-11 08:04:35.931] [info] schedule queue 1 closed\n",
-            "[2023-07-11 08:04:35.931] [info] all scheduling threads were joint\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -875,43 +293,10 @@
         "! rm -rf decode_scale_encode_output.mp4"
       ],
       "metadata": {
-        "id": "2Px4bZmK4lWm",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "779376ba-39f3-440a-8893-d4b8694ef11e"
+        "id": "2Px4bZmK4lWm"
       },
-      "execution_count": 21,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "ffprobe version 4.2.7-0ubuntu0.1 Copyright (c) 2007-2022 the FFmpeg developers\n",
-            "  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)\n",
-            "  configuration: --prefix=/usr --extra-version=0ubuntu0.1 --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu --incdir=/usr/include/x86_64-linux-gnu --arch=amd64 --enable-gpl --disable-stripping --enable-avresample --disable-filter=resample --enable-avisynth --enable-gnutls --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libjack --enable-libmp3lame --enable-libmysofa --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse --enable-librsvg --enable-librubberband --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libssh --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwavpack --enable-libwebp --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzmq --enable-libzvbi --enable-lv2 --enable-omx --enable-openal --enable-opencl --enable-opengl --enable-sdl2 --enable-libdc1394 --enable-libdrm --enable-libiec61883 --enable-nvenc --enable-chromaprint --enable-frei0r --enable-libx264 --enable-shared\n",
-            "  libavutil      56. 31.100 / 56. 31.100\n",
-            "  libavcodec     58. 54.100 / 58. 54.100\n",
-            "  libavformat    58. 29.100 / 58. 29.100\n",
-            "  libavdevice    58.  8.100 / 58.  8.100\n",
-            "  libavfilter     7. 57.100 /  7. 57.100\n",
-            "  libavresample   4.  0.  0 /  4.  0.  0\n",
-            "  libswscale      5.  5.100 /  5.  5.100\n",
-            "  libswresample   3.  5.100 /  3.  5.100\n",
-            "  libpostproc    55.  5.100 / 55.  5.100\n",
-            "Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'decode_scale_encode_output.mp4':\n",
-            "  Metadata:\n",
-            "    major_brand     : isom\n",
-            "    minor_version   : 512\n",
-            "    compatible_brands: isomiso2mp41\n",
-            "    encoder         : Lavf58.29.100\n",
-            "  Duration: 00:00:10.00, start: 0.000000, bitrate: 164 kb/s\n",
-            "    Stream #0:0(und): Video: hevc (Main) (hev1 / 0x31766568), yuv420p(tv), 720x576 [SAR 64:45 DAR 16:9], 158 kb/s, 30 fps, 30 tbr, 15360 tbn, 30 tbc (default)\n",
-            "    Metadata:\n",
-            "      handler_name    : VideoHandler\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -953,367 +338,10 @@
         ")"
       ],
       "metadata": {
-        "id": "EB62DCjXDFf_",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "7181337f-6422-494c-9317-453bb404f1f1"
+        "id": "EB62DCjXDFf_"
       },
-      "execution_count": 22,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "{\n",
-            "    \"input_streams\": [],\n",
-            "    \"output_streams\": [],\n",
-            "    \"nodes\": [\n",
-            "        {\n",
-            "            \"module_info\": {\n",
-            "                \"name\": \"c_ffmpeg_decoder\",\n",
-            "                \"type\": \"\",\n",
-            "                \"path\": \"\",\n",
-            "                \"entry\": \"\"\n",
-            "            },\n",
-            "            \"meta_info\": {\n",
-            "                \"premodule_id\": -1,\n",
-            "                \"callback_binding\": []\n",
-            "            },\n",
-            "            \"option\": {\n",
-            "                \"input_path\": \"./big_bunny_10s_30fps.mp4\"\n",
-            "            },\n",
-            "            \"input_streams\": [],\n",
-            "            \"output_streams\": [\n",
-            "                {\n",
-            "                    \"identifier\": \"video:c_ffmpeg_decoder_19_1\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                },\n",
-            "                {\n",
-            "                    \"identifier\": \"audio:c_ffmpeg_decoder_19_2\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                }\n",
-            "            ],\n",
-            "            \"input_manager\": \"immediate\",\n",
-            "            \"scheduler\": 0,\n",
-            "            \"alias\": \"\",\n",
-            "            \"id\": 19\n",
-            "        },\n",
-            "        {\n",
-            "            \"module_info\": {\n",
-            "                \"name\": \"c_ffmpeg_filter\",\n",
-            "                \"type\": \"\",\n",
-            "                \"path\": \"\",\n",
-            "                \"entry\": \"\"\n",
-            "            },\n",
-            "            \"meta_info\": {\n",
-            "                \"premodule_id\": -1,\n",
-            "                \"callback_binding\": []\n",
-            "            },\n",
-            "            \"option\": {\n",
-            "                \"name\": \"split\"\n",
-            "            },\n",
-            "            \"input_streams\": [\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_decoder_19_1\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                }\n",
-            "            ],\n",
-            "            \"output_streams\": [\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_filter_20_0\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                },\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_filter_20_1\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                }\n",
-            "            ],\n",
-            "            \"input_manager\": \"immediate\",\n",
-            "            \"scheduler\": 0,\n",
-            "            \"alias\": \"\",\n",
-            "            \"id\": 20\n",
-            "        },\n",
-            "        {\n",
-            "            \"module_info\": {\n",
-            "                \"name\": \"c_ffmpeg_encoder\",\n",
-            "                \"type\": \"\",\n",
-            "                \"path\": \"\",\n",
-            "                \"entry\": \"\"\n",
-            "            },\n",
-            "            \"meta_info\": {\n",
-            "                \"premodule_id\": -1,\n",
-            "                \"callback_binding\": []\n",
-            "            },\n",
-            "            \"option\": {\n",
-            "                \"output_path\": \"./decode_encode_multi_output0.mp4\",\n",
-            "                \"video_params\": {\n",
-            "                    \"codec\": \"libx264\",\n",
-            "                    \"x264-params\": \"ssim=1:psnr=1\"\n",
-            "                }\n",
-            "            },\n",
-            "            \"input_streams\": [\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_filter_20_0\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                },\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_decoder_19_2\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                }\n",
-            "            ],\n",
-            "            \"output_streams\": [],\n",
-            "            \"input_manager\": \"immediate\",\n",
-            "            \"scheduler\": 1,\n",
-            "            \"alias\": \"\",\n",
-            "            \"id\": 21\n",
-            "        },\n",
-            "        {\n",
-            "            \"module_info\": {\n",
-            "                \"name\": \"c_ffmpeg_encoder\",\n",
-            "                \"type\": \"\",\n",
-            "                \"path\": \"\",\n",
-            "                \"entry\": \"\"\n",
-            "            },\n",
-            "            \"meta_info\": {\n",
-            "                \"premodule_id\": -1,\n",
-            "                \"callback_binding\": []\n",
-            "            },\n",
-            "            \"option\": {\n",
-            "                \"output_path\": \"./decode_encode_multi_output1.mp4\",\n",
-            "                \"video_params\": {\n",
-            "                    \"codec\": \"libx265\",\n",
-            "                    \"preset\": \"fast\",\n",
-            "                    \"crf\": \"23\"\n",
-            "                }\n",
-            "            },\n",
-            "            \"input_streams\": [\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_filter_20_1\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                },\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_decoder_19_2\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                }\n",
-            "            ],\n",
-            "            \"output_streams\": [],\n",
-            "            \"input_manager\": \"immediate\",\n",
-            "            \"scheduler\": 1,\n",
-            "            \"alias\": \"\",\n",
-            "            \"id\": 22\n",
-            "        }\n",
-            "    ],\n",
-            "    \"option\": {},\n",
-            "    \"mode\": \"Normal\"\n",
-            "}\n",
-            "[2023-07-11 08:05:41.646] [info] Constructing c++ module\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Input #0, mov,mp4,m4a,3gp,3g2,mj2, from './big_bunny_10s_30fps.mp4':\n",
-            "  Metadata:\n",
-            "    major_brand     : isom\n",
-            "    minor_version   : 512\n",
-            "    compatible_brands: isomiso2avc1mp41\n",
-            "    encoder         : Lavf58.76.100\n",
-            "  Duration: 00:00:10.00, start: 0.000000, bitrate: 2044 kb/s\n",
-            "    Stream #0:0(und): Video: h264 (High) (avc1 / 0x31637661), yuv420p, 1920x1080 [SAR 1:1 DAR 16:9], 1904 kb/s, 30 fps, 30 tbr, 15360 tbn, 60 tbc (default)\n",
-            "    Metadata:\n",
-            "      handler_name    : VideoHandler\n",
-            "    Stream #0:1(und): Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 129 kb/s (default)\n",
-            "    Metadata:\n",
-            "      handler_name    : SoundHandler\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "[2023-07-11 08:05:41.660] [info] c++ module constructed\n",
-            "[2023-07-11 08:05:41.660] [info] Constructing c++ module\n",
-            "[2023-07-11 08:05:41.660] [info] c++ module constructed\n",
-            "[2023-07-11 08:05:41.660] [info] Constructing c++ module\n",
-            "[2023-07-11 08:05:41.660] [info] c++ module constructed\n",
-            "[2023-07-11 08:05:41.660] [info] Constructing c++ module\n",
-            "[2023-07-11 08:05:41.660] [info] c++ module constructed\n",
-            "[2023-07-11 08:05:41.660] [info] BMF Version: 0.0.5\n",
-            "[2023-07-11 08:05:41.660] [info] BMF Commit: 98e17ef\n",
-            "[2023-07-11 08:05:41.660] [info] start init graph\n",
-            "[2023-07-11 08:05:41.660] [info] scheduler count2\n",
-            "debug queue size, node 19, queue size: 5\n",
-            "[2023-07-11 08:05:41.660] [info] node:c_ffmpeg_decoder 19 scheduler 0\n",
-            "debug queue size, node 21, queue size: 5\n",
-            "[2023-07-11 08:05:41.661] [info] node:c_ffmpeg_encoder 21 scheduler 1\n",
-            "debug queue size, node 22, queue size: 5\n",
-            "[2023-07-11 08:05:41.661] [info] node:c_ffmpeg_encoder 22 scheduler 1\n",
-            "debug queue size, node 20, queue size: 5\n",
-            "[2023-07-11 08:05:41.661] [info] Constructing c++ module\n",
-            "[2023-07-11 08:05:41.661] [info] c++ module constructed\n",
-            "[2023-07-11 08:05:41.661] [info] node:c_ffmpeg_filter 20 scheduler 0\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[libx264 @ 0x7f3628261f00] --psnr used with psy on: results will be invalid!\n",
-            "[libx264 @ 0x7f3628261f00] --tune psnr should be used if attempting to benchmark psnr!\n",
-            "[libx264 @ 0x7f3628261f00] using SAR=1/1\n",
-            "[libx264 @ 0x7f3628261f00] using cpu capabilities: MMX2 SSE2Fast SSSE3 SSE4.2 AVX FMA3 BMI2 AVX2\n",
-            "[libx264 @ 0x7f3628261f00] profile High, level 4.0\n",
-            "[libx264 @ 0x7f3628261f00] 264 - core 155 r2917 0a84d98 - H.264/MPEG-4 AVC codec - Copyleft 2003-2018 - http://www.videolan.org/x264.html - options: cabac=1 ref=3 deblock=1:0:0 analyse=0x3:0x113 me=hex subme=7 psy=1 psy_rd=1.00:0.00 mixed_ref=1 me_range=16 chroma_me=1 trellis=1 8x8dct=1 cqm=0 deadzone=21,11 fast_pskip=1 chroma_qp_offset=-2 threads=3 lookahead_threads=1 sliced_threads=0 nr=0 decimate=1 interlaced=0 bluray_compat=0 constrained_intra=0 bframes=3 b_pyramid=2 b_adapt=1 b_bias=0 direct=1 weightb=1 open_gop=0 weightp=2 keyint=250 keyint_min=25 scenecut=40 intra_refresh=0 rc_lookahead=40 rc=crf mbtree=1 crf=23.0 qcomp=0.60 qpmin=0 qpmax=69 qpstep=4 ip_ratio=1.40 aq=1:1.00\n",
-            "Output #0, mp4, to './decode_encode_multi_output0.mp4':\n",
-            "  Metadata:\n",
-            "    encoder         : Lavf58.29.100\n",
-            "    Stream #0:0: Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 128 kb/s\n",
-            "    Stream #0:1: Video: h264 (avc1 / 0x31637661), yuv420p, 1920x1080 [SAR 1:1 DAR 16:9], q=2-31, 30 fps, 30 tbr, 15360 tbn, 30 tbc\n",
-            "x265 [info]: HEVC encoder version 3.2.1+1-b5c86a64bbbe\n",
-            "x265 [info]: build info [Linux][GCC 9.3.0][64 bit] 8bit+10bit+12bit\n",
-            "x265 [info]: using cpu capabilities: MMX2 SSE2Fast LZCNT SSSE3 SSE4.2 AVX FMA3 BMI2 AVX2\n",
-            "x265 [info]: Main profile, Level-4 (Main tier)\n",
-            "x265 [info]: Thread pool created using 2 threads\n",
-            "x265 [info]: Slices                              : 1\n",
-            "x265 [info]: frame threads / pool features       : 1 / wpp(17 rows)\n",
-            "set_mempolicy: Operation not permitted\n",
-            "set_mempolicy: Operation not permitted\n",
-            "set_mempolicy: Operation not permitted\n",
-            "set_mempolicy: Operation not permitted\n",
-            "set_mempolicy: Operation not permitted\n",
-            "set_mempolicy: Operation not permitted\n",
-            "x265 [info]: Coding QT: max CU size, min CU size : 64 / 8\n",
-            "x265 [info]: Residual QT: max TU size, max depth : 32 / 1 inter / 1 intra\n",
-            "x265 [info]: ME / range / subpel / merge         : hex / 57 / 2 / 2\n",
-            "x265 [info]: Keyframe min / max / scenecut / bias: 25 / 250 / 40 / 5.00\n",
-            "x265 [info]: Lookahead / bframes / badapt        : 15 / 4 / 0\n",
-            "x265 [info]: b-pyramid / weightp / weightb       : 1 / 1 / 0\n",
-            "x265 [info]: References / ref-limit  cu / depth  : 3 / on / on\n",
-            "x265 [info]: AQ: mode / str / qg-size / cu-tree  : 2 / 1.0 / 32 / 1\n",
-            "x265 [info]: Rate Control / qCompress            : CRF-23.0 / 0.60\n",
-            "x265 [info]: tools: rd=2 psy-rd=2.00 rskip signhide tmvp fast-intra\n",
-            "x265 [info]: tools: strong-intra-smoothing lslices=6 deblock sao\n",
-            "Output #0, mp4, to './decode_encode_multi_output1.mp4':\n",
-            "  Metadata:\n",
-            "    encoder         : Lavf58.29.100\n",
-            "    Stream #0:0: Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 128 kb/s\n",
-            "    Stream #0:1: Video: hevc (hev1 / 0x31766568), yuv420p, 1920x1080 [SAR 1:1 DAR 16:9], q=2-31, 30 fps, 30 tbr, 15360 tbn, 30 tbc\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "[2023-07-11 08:05:43.626] [info] schedule queue 0 start to join thread\n",
-            "[2023-07-11 08:05:43.626] [info] schedule queue 0 closed\n",
-            "[2023-07-11 08:05:43.626] [info] schedule queue 1 start to join thread\n",
-            "[2023-07-11 08:05:43.626] [info] schedule queue 1 closed\n",
-            "[2023-07-11 08:05:43.626] [info] all scheduling threads were joint\n",
-            "[2023-07-11 08:05:43.626] [info] node id:16 video frame decoded:300\n",
-            "[2023-07-11 08:05:43.626] [info] node id:16 audio frame decoded:0, sample decoded:0\n",
-            "[2023-07-11 08:06:36.800] [info] node id:19 decode flushing\n",
-            "[2023-07-11 08:06:36.800] [info] node id:19 Process node end\n",
-            "[2023-07-11 08:06:36.806] [info] node id:19 close node\n",
-            "[2023-07-11 08:06:36.806] [info] node 19 close report, closed count: 1\n",
-            "[2023-07-11 08:06:36.806] [info] node id:20 eof received\n",
-            "[2023-07-11 08:06:36.806] [info] node id:20 eof processed, remove node from scheduler\n",
-            "[2023-07-11 08:06:36.807] [info] node id:21 eof received\n",
-            "[2023-07-11 08:06:36.807] [info] node id:22 eof received\n",
-            "[2023-07-11 08:06:36.807] [info] node id:20 process eof, add node to scheduler\n",
-            "[2023-07-11 08:06:36.807] [info] node id:20 Process node end\n",
-            "[2023-07-11 08:06:36.811] [info] node id:20 close node\n",
-            "[2023-07-11 08:06:36.811] [info] node 20 close report, closed count: 2\n",
-            "[2023-07-11 08:06:36.811] [info] node id:21 eof received\n",
-            "[2023-07-11 08:06:36.811] [info] node id:22 eof received\n",
-            "[2023-07-11 08:06:37.408] [info] node id:21 eof processed, remove node from scheduler\n",
-            "[2023-07-11 08:06:37.408] [info] node id:21 eof processed, remove node from scheduler\n",
-            "[2023-07-11 08:06:38.365] [info] node id:22 eof processed, remove node from scheduler\n",
-            "[2023-07-11 08:06:38.365] [info] node id:22 eof processed, remove node from scheduler\n",
-            "[2023-07-11 08:06:40.964] [info] node id:21 process eof, add node to scheduler\n",
-            "[2023-07-11 08:06:47.232] [info] node id:21 Process node end\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[libx264 @ 0x7f3628261f00] frame I:3     Avg QP:10.39  size: 11601  PSNR Mean Y:78.09 U:81.85 V:79.67 Avg:78.56 Global:69.58\n",
-            "[libx264 @ 0x7f3628261f00] frame P:87    Avg QP:17.72  size: 18072  PSNR Mean Y:52.72 U:56.93 V:56.00 Avg:53.48 Global:49.43\n",
-            "[libx264 @ 0x7f3628261f00] frame B:210   Avg QP:20.33  size:  2942  PSNR Mean Y:52.10 U:56.01 V:55.04 Avg:52.82 Global:49.20\n",
-            "[libx264 @ 0x7f3628261f00] consecutive B-frames:  2.7%  9.3%  8.0% 80.0%\n",
-            "[libx264 @ 0x7f3628261f00] mb I  I16..4: 61.8% 35.3%  2.9%\n",
-            "[libx264 @ 0x7f3628261f00] mb P  I16..4:  5.1% 14.4%  0.4%  P16..4: 13.9%  3.5%  3.0%  0.0%  0.0%    skip:59.6%\n",
-            "[libx264 @ 0x7f3628261f00] mb B  I16..4:  1.0%  0.7%  0.0%  B16..8: 14.7%  1.2%  0.2%  direct: 4.2%  skip:77.9%  L0:52.8% L1:43.1% BI: 4.1%\n",
-            "[libx264 @ 0x7f3628261f00] 8x8 transform intra:63.1% inter:67.9%\n",
-            "[libx264 @ 0x7f3628261f00] coded y,uvDC,uvAC intra: 7.0% 29.1% 3.0% inter: 2.6% 7.7% 0.4%\n",
-            "[libx264 @ 0x7f3628261f00] i16 v,h,dc,p: 65% 21% 10%  4%\n",
-            "[libx264 @ 0x7f3628261f00] i8 v,h,dc,ddl,ddr,vr,hd,vl,hu: 41% 15% 42%  0%  0%  0%  0%  0%  0%\n",
-            "[libx264 @ 0x7f3628261f00] i4 v,h,dc,ddl,ddr,vr,hd,vl,hu: 40% 15% 19%  4%  5%  4%  5%  3%  5%\n",
-            "[libx264 @ 0x7f3628261f00] i8c dc,h,v,p: 68% 18% 14%  1%\n",
-            "[libx264 @ 0x7f3628261f00] Weighted P-Frames: Y:18.4% UV:18.4%\n",
-            "[libx264 @ 0x7f3628261f00] ref P L0: 75.4%  4.5% 15.3%  4.8%  0.0%\n",
-            "[libx264 @ 0x7f3628261f00] ref B L0: 89.4%  9.3%  1.2%\n",
-            "[libx264 @ 0x7f3628261f00] ref B L1: 97.9%  2.1%\n",
-            "[libx264 @ 0x7f3628261f00] SSIM Mean Y:0.9978791 (26.735db)\n",
-            "[libx264 @ 0x7f3628261f00] PSNR Mean Y:52.537 U:56.531 V:55.561 Avg:53.273 Global:49.313 kb/s:1779.85\n",
-            "[aac @ 0x7f3628002480] "
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "[2023-07-11 08:06:47.248] [info] node id:21 close node\n",
-            "[2023-07-11 08:06:47.248] [info] node 21 close report, closed count: 3\n",
-            "[2023-07-11 08:06:47.248] [info] node id:22 process eof, add node to scheduler\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Qavg: 850.216\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "[2023-07-11 08:06:50.954] [info] node id:22 Process node end\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "x265 [info]: frame I:      3, Avg QP:26.32  kb/s: 654.48  \n",
-            "x265 [info]: frame P:     61, Avg QP:24.68  kb/s: 5386.23 \n",
-            "x265 [info]: frame B:    236, Avg QP:29.70  kb/s: 302.40  \n",
-            "x265 [info]: Weighted P-Frames: Y:14.8% UV:13.1%\n",
-            "x265 [info]: consecutive B-frames: 4.7% 3.1% 1.6% 0.0% 90.6% \n",
-            "\n",
-            "encoded 300 frames in 69.18s (4.34 fps), 1339.63 kb/s, Avg QP:28.64\n",
-            "[aac @ 0x7f362812dfc0] Qavg: 850.216\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "[2023-07-11 08:06:50.979] [info] node id:22 close node\n",
-            "[2023-07-11 08:06:50.979] [info] node 22 close report, closed count: 4\n",
-            "[2023-07-11 08:06:50.979] [info] schedule queue 0 start to join thread\n",
-            "[2023-07-11 08:06:50.979] [info] schedule queue 0 thread quit\n",
-            "[2023-07-11 08:06:50.980] [info] schedule queue 0 closed\n",
-            "[2023-07-11 08:06:50.980] [info] schedule queue 1 start to join thread\n",
-            "[2023-07-11 08:06:50.980] [info] schedule queue 1 thread quit\n",
-            "[2023-07-11 08:06:50.980] [info] schedule queue 1 closed\n",
-            "[2023-07-11 08:06:50.980] [info] all scheduling threads were joint\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -1325,72 +353,10 @@
         "! rm -rf decode_encode_multi_output0.mp4 decode_encode_multi_output1.mp4"
       ],
       "metadata": {
-        "id": "DpxOsI0g6qrZ",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "72b2b8d4-ce2b-460b-bf29-2176c228a5de"
+        "id": "DpxOsI0g6qrZ"
       },
-      "execution_count": 23,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "ffprobe version 4.2.7-0ubuntu0.1 Copyright (c) 2007-2022 the FFmpeg developers\n",
-            "  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)\n",
-            "  configuration: --prefix=/usr --extra-version=0ubuntu0.1 --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu --incdir=/usr/include/x86_64-linux-gnu --arch=amd64 --enable-gpl --disable-stripping --enable-avresample --disable-filter=resample --enable-avisynth --enable-gnutls --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libjack --enable-libmp3lame --enable-libmysofa --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse --enable-librsvg --enable-librubberband --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libssh --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwavpack --enable-libwebp --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzmq --enable-libzvbi --enable-lv2 --enable-omx --enable-openal --enable-opencl --enable-opengl --enable-sdl2 --enable-libdc1394 --enable-libdrm --enable-libiec61883 --enable-nvenc --enable-chromaprint --enable-frei0r --enable-libx264 --enable-shared\n",
-            "  libavutil      56. 31.100 / 56. 31.100\n",
-            "  libavcodec     58. 54.100 / 58. 54.100\n",
-            "  libavformat    58. 29.100 / 58. 29.100\n",
-            "  libavdevice    58.  8.100 / 58.  8.100\n",
-            "  libavfilter     7. 57.100 /  7. 57.100\n",
-            "  libavresample   4.  0.  0 /  4.  0.  0\n",
-            "  libswscale      5.  5.100 /  5.  5.100\n",
-            "  libswresample   3.  5.100 /  3.  5.100\n",
-            "  libpostproc    55.  5.100 / 55.  5.100\n",
-            "Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'decode_encode_multi_output0.mp4':\n",
-            "  Metadata:\n",
-            "    major_brand     : isom\n",
-            "    minor_version   : 512\n",
-            "    compatible_brands: isomiso2avc1mp41\n",
-            "    encoder         : Lavf58.29.100\n",
-            "  Duration: 00:00:10.03, start: 0.000000, bitrate: 1915 kb/s\n",
-            "    Stream #0:0(und): Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 130 kb/s (default)\n",
-            "    Metadata:\n",
-            "      handler_name    : SoundHandler\n",
-            "    Stream #0:1(und): Video: h264 (High) (avc1 / 0x31637661), yuv420p, 1920x1080 [SAR 1:1 DAR 16:9], 1780 kb/s, 30 fps, 30 tbr, 15360 tbn, 60 tbc (default)\n",
-            "    Metadata:\n",
-            "      handler_name    : VideoHandler\n",
-            "----------------------------------------------------------------------\n",
-            "ffprobe version 4.2.7-0ubuntu0.1 Copyright (c) 2007-2022 the FFmpeg developers\n",
-            "  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)\n",
-            "  configuration: --prefix=/usr --extra-version=0ubuntu0.1 --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu --incdir=/usr/include/x86_64-linux-gnu --arch=amd64 --enable-gpl --disable-stripping --enable-avresample --disable-filter=resample --enable-avisynth --enable-gnutls --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libjack --enable-libmp3lame --enable-libmysofa --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse --enable-librsvg --enable-librubberband --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libssh --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwavpack --enable-libwebp --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzmq --enable-libzvbi --enable-lv2 --enable-omx --enable-openal --enable-opencl --enable-opengl --enable-sdl2 --enable-libdc1394 --enable-libdrm --enable-libiec61883 --enable-nvenc --enable-chromaprint --enable-frei0r --enable-libx264 --enable-shared\n",
-            "  libavutil      56. 31.100 / 56. 31.100\n",
-            "  libavcodec     58. 54.100 / 58. 54.100\n",
-            "  libavformat    58. 29.100 / 58. 29.100\n",
-            "  libavdevice    58.  8.100 / 58.  8.100\n",
-            "  libavfilter     7. 57.100 /  7. 57.100\n",
-            "  libavresample   4.  0.  0 /  4.  0.  0\n",
-            "  libswscale      5.  5.100 /  5.  5.100\n",
-            "  libswresample   3.  5.100 /  3.  5.100\n",
-            "  libpostproc    55.  5.100 / 55.  5.100\n",
-            "Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'decode_encode_multi_output1.mp4':\n",
-            "  Metadata:\n",
-            "    major_brand     : isom\n",
-            "    minor_version   : 512\n",
-            "    compatible_brands: isomiso2mp41\n",
-            "    encoder         : Lavf58.29.100\n",
-            "  Duration: 00:00:10.03, start: 0.000000, bitrate: 1478 kb/s\n",
-            "    Stream #0:0(und): Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 130 kb/s (default)\n",
-            "    Metadata:\n",
-            "      handler_name    : SoundHandler\n",
-            "    Stream #0:1(und): Video: hevc (Main) (hev1 / 0x31766568), yuv420p(tv), 1920x1080 [SAR 1:1 DAR 16:9], 1340 kb/s, 30 fps, 30 tbr, 15360 tbn, 30 tbc (default)\n",
-            "    Metadata:\n",
-            "      handler_name    : VideoHandler\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -1451,367 +417,10 @@
         ")"
       ],
       "metadata": {
-        "id": "z9zqj2leWHx1",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "32dde7c8-f5d4-4c79-bf85-eb9f820a5513"
+        "id": "z9zqj2leWHx1"
       },
-      "execution_count": 24,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "{\n",
-            "    \"input_streams\": [],\n",
-            "    \"output_streams\": [],\n",
-            "    \"nodes\": [\n",
-            "        {\n",
-            "            \"module_info\": {\n",
-            "                \"name\": \"c_ffmpeg_decoder\",\n",
-            "                \"type\": \"\",\n",
-            "                \"path\": \"\",\n",
-            "                \"entry\": \"\"\n",
-            "            },\n",
-            "            \"meta_info\": {\n",
-            "                \"premodule_id\": -1,\n",
-            "                \"callback_binding\": []\n",
-            "            },\n",
-            "            \"option\": {\n",
-            "                \"input_path\": \"./big_bunny_10s_30fps.mp4\"\n",
-            "            },\n",
-            "            \"input_streams\": [],\n",
-            "            \"output_streams\": [\n",
-            "                {\n",
-            "                    \"identifier\": \"audio:c_ffmpeg_decoder_23_1\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                }\n",
-            "            ],\n",
-            "            \"input_manager\": \"immediate\",\n",
-            "            \"scheduler\": 0,\n",
-            "            \"alias\": \"\",\n",
-            "            \"id\": 23\n",
-            "        },\n",
-            "        {\n",
-            "            \"module_info\": {\n",
-            "                \"name\": \"c_ffmpeg_filter\",\n",
-            "                \"type\": \"\",\n",
-            "                \"path\": \"\",\n",
-            "                \"entry\": \"\"\n",
-            "            },\n",
-            "            \"meta_info\": {\n",
-            "                \"premodule_id\": -1,\n",
-            "                \"callback_binding\": []\n",
-            "            },\n",
-            "            \"option\": {\n",
-            "                \"name\": \"anullsrc\",\n",
-            "                \"para\": \"r=48000:cl=2\"\n",
-            "            },\n",
-            "            \"input_streams\": [],\n",
-            "            \"output_streams\": [\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_filter_24_0\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                }\n",
-            "            ],\n",
-            "            \"input_manager\": \"immediate\",\n",
-            "            \"scheduler\": 0,\n",
-            "            \"alias\": \"\",\n",
-            "            \"id\": 24\n",
-            "        },\n",
-            "        {\n",
-            "            \"module_info\": {\n",
-            "                \"name\": \"c_ffmpeg_filter\",\n",
-            "                \"type\": \"\",\n",
-            "                \"path\": \"\",\n",
-            "                \"entry\": \"\"\n",
-            "            },\n",
-            "            \"meta_info\": {\n",
-            "                \"premodule_id\": -1,\n",
-            "                \"callback_binding\": []\n",
-            "            },\n",
-            "            \"option\": {\n",
-            "                \"name\": \"atrim\",\n",
-            "                \"para\": \"start=0:end=6\"\n",
-            "            },\n",
-            "            \"input_streams\": [\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_filter_24_0\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                }\n",
-            "            ],\n",
-            "            \"output_streams\": [\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_filter_25_0\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                }\n",
-            "            ],\n",
-            "            \"input_manager\": \"immediate\",\n",
-            "            \"scheduler\": 0,\n",
-            "            \"alias\": \"\",\n",
-            "            \"id\": 25\n",
-            "        },\n",
-            "        {\n",
-            "            \"module_info\": {\n",
-            "                \"name\": \"c_ffmpeg_filter\",\n",
-            "                \"type\": \"\",\n",
-            "                \"path\": \"\",\n",
-            "                \"entry\": \"\"\n",
-            "            },\n",
-            "            \"meta_info\": {\n",
-            "                \"premodule_id\": -1,\n",
-            "                \"callback_binding\": []\n",
-            "            },\n",
-            "            \"option\": {\n",
-            "                \"name\": \"anullsrc\",\n",
-            "                \"para\": \"r=48000:cl=2\"\n",
-            "            },\n",
-            "            \"input_streams\": [],\n",
-            "            \"output_streams\": [\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_filter_26_0\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                }\n",
-            "            ],\n",
-            "            \"input_manager\": \"immediate\",\n",
-            "            \"scheduler\": 0,\n",
-            "            \"alias\": \"\",\n",
-            "            \"id\": 26\n",
-            "        },\n",
-            "        {\n",
-            "            \"module_info\": {\n",
-            "                \"name\": \"c_ffmpeg_filter\",\n",
-            "                \"type\": \"\",\n",
-            "                \"path\": \"\",\n",
-            "                \"entry\": \"\"\n",
-            "            },\n",
-            "            \"meta_info\": {\n",
-            "                \"premodule_id\": -1,\n",
-            "                \"callback_binding\": []\n",
-            "            },\n",
-            "            \"option\": {\n",
-            "                \"name\": \"atrim\",\n",
-            "                \"para\": \"start=0:end=6\"\n",
-            "            },\n",
-            "            \"input_streams\": [\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_filter_26_0\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                }\n",
-            "            ],\n",
-            "            \"output_streams\": [\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_filter_27_0\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                }\n",
-            "            ],\n",
-            "            \"input_manager\": \"immediate\",\n",
-            "            \"scheduler\": 0,\n",
-            "            \"alias\": \"\",\n",
-            "            \"id\": 27\n",
-            "        },\n",
-            "        {\n",
-            "            \"module_info\": {\n",
-            "                \"name\": \"c_ffmpeg_filter\",\n",
-            "                \"type\": \"\",\n",
-            "                \"path\": \"\",\n",
-            "                \"entry\": \"\"\n",
-            "            },\n",
-            "            \"meta_info\": {\n",
-            "                \"premodule_id\": -1,\n",
-            "                \"callback_binding\": []\n",
-            "            },\n",
-            "            \"option\": {\n",
-            "                \"name\": \"concat\",\n",
-            "                \"para\": \"a=1:n=3:v=0\"\n",
-            "            },\n",
-            "            \"input_streams\": [\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_filter_25_0\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                },\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_decoder_23_1\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                },\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_filter_27_0\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                }\n",
-            "            ],\n",
-            "            \"output_streams\": [\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_filter_28_0\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                }\n",
-            "            ],\n",
-            "            \"input_manager\": \"immediate\",\n",
-            "            \"scheduler\": 0,\n",
-            "            \"alias\": \"\",\n",
-            "            \"id\": 28\n",
-            "        },\n",
-            "        {\n",
-            "            \"module_info\": {\n",
-            "                \"name\": \"c_ffmpeg_encoder\",\n",
-            "                \"type\": \"\",\n",
-            "                \"path\": \"\",\n",
-            "                \"entry\": \"\"\n",
-            "            },\n",
-            "            \"meta_info\": {\n",
-            "                \"premodule_id\": -1,\n",
-            "                \"callback_binding\": []\n",
-            "            },\n",
-            "            \"option\": {\n",
-            "                \"output_path\": \"./with_null_audio.wav\",\n",
-            "                \"audio_params\": {\n",
-            "                    \"codec\": \"aac\",\n",
-            "                    \"bit_rate\": 128000,\n",
-            "                    \"sample_rate\": 44100,\n",
-            "                    \"channels\": 2\n",
-            "                }\n",
-            "            },\n",
-            "            \"input_streams\": [\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_encoder_29_1\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                },\n",
-            "                {\n",
-            "                    \"identifier\": \"c_ffmpeg_filter_28_0\",\n",
-            "                    \"stream_alias\": \"\"\n",
-            "                }\n",
-            "            ],\n",
-            "            \"output_streams\": [],\n",
-            "            \"input_manager\": \"immediate\",\n",
-            "            \"scheduler\": 1,\n",
-            "            \"alias\": \"\",\n",
-            "            \"id\": 29\n",
-            "        }\n",
-            "    ],\n",
-            "    \"option\": {},\n",
-            "    \"mode\": \"Normal\"\n",
-            "}\n",
-            "[2023-07-11 08:06:51.364] [info] Constructing c++ module\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Input #0, mov,mp4,m4a,3gp,3g2,mj2, from './big_bunny_10s_30fps.mp4':\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "[2023-07-11 08:06:51.375] [info] c++ module constructed\n",
-            "[2023-07-11 08:06:51.375] [info] Constructing c++ module\n",
-            "[2023-07-11 08:06:51.375] [info] c++ module constructed\n",
-            "[2023-07-11 08:06:51.375] [info] Constructing c++ module\n",
-            "[2023-07-11 08:06:51.375] [info] c++ module constructed\n",
-            "[2023-07-11 08:06:51.375] [info] Constructing c++ module\n",
-            "[2023-07-11 08:06:51.375] [info] c++ module constructed\n",
-            "[2023-07-11 08:06:51.375] [info] Constructing c++ module\n",
-            "[2023-07-11 08:06:51.375] [info] c++ module constructed\n",
-            "[2023-07-11 08:06:51.375] [info] Constructing c++ module\n",
-            "[2023-07-11 08:06:51.375] [info] c++ module constructed\n",
-            "[2023-07-11 08:06:51.375] [info] Constructing c++ module\n",
-            "[2023-07-11 08:06:51.375] [info] c++ module constructed\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "  Metadata:\n",
-            "    major_brand     : isom\n",
-            "    minor_version   : 512\n",
-            "    compatible_brands: isomiso2avc1mp41\n",
-            "    encoder         : Lavf58.76.100\n",
-            "  Duration: 00:00:10.00, start: 0.000000, bitrate: 2044 kb/s\n",
-            "    Stream #0:0(und): Video: h264 (High) (avc1 / 0x31637661), yuv420p, 1920x1080 [SAR 1:1 DAR 16:9], 1904 kb/s, 30 fps, 30 tbr, 15360 tbn, 60 tbc (default)\n",
-            "    Metadata:\n",
-            "      handler_name    : VideoHandler\n",
-            "    Stream #0:1(und): Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 129 kb/s (default)\n",
-            "    Metadata:\n",
-            "      handler_name    : SoundHandler\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "[2023-07-11 08:06:51.382] [info] BMF Version: 0.0.5\n",
-            "[2023-07-11 08:06:51.385] [info] BMF Commit: 98e17ef\n",
-            "[2023-07-11 08:06:51.385] [info] start init graph\n",
-            "[2023-07-11 08:06:51.385] [info] scheduler count2\n",
-            "debug queue size, node 23, queue size: 5\n",
-            "[2023-07-11 08:06:51.385] [info] node:c_ffmpeg_decoder 23 scheduler 0\n",
-            "debug queue size, node 29, queue size: 5\n",
-            "[2023-07-11 08:06:51.386] [info] node:c_ffmpeg_encoder 29 scheduler 1\n",
-            "debug queue size, node 24, queue size: 5\n",
-            "[2023-07-11 08:06:51.386] [info] Constructing c++ module\n",
-            "[2023-07-11 08:06:51.386] [info] c++ module constructed\n",
-            "[2023-07-11 08:06:51.386] [info] node:c_ffmpeg_filter 24 scheduler 0\n",
-            "[2023-07-11 08:06:51.388] [info] node id:29 eof received\n",
-            "[2023-07-11 08:06:51.389] [info] push eof to orphan stream c_ffmpeg_encoder_29_1\n",
-            "[2023-07-11 08:06:51.402] [info] node id:29 eof processed, remove node from scheduler\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Output #0, mp4, to './with_null_audio.wav':\n",
-            "  Metadata:\n",
-            "    encoder         : Lavf58.29.100\n",
-            "    Stream #0:0: Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 128 kb/s\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "[2023-07-11 08:06:51.667] [info] node id:23 decode flushing\n",
-            "[2023-07-11 08:06:51.677] [info] node id:23 Process node end\n",
-            "[2023-07-11 08:06:51.689] [info] node id:23 close node\n",
-            "[2023-07-11 08:06:51.691] [info] node 23 close report, closed count: 1\n",
-            "[2023-07-11 08:06:51.691] [info] node id:24 eof received\n",
-            "[2023-07-11 08:06:51.691] [info] node id:24 eof processed, remove node from scheduler\n",
-            "[2023-07-11 08:06:51.692] [info] node id:24 process eof, add node to scheduler\n",
-            "[2023-07-11 08:06:51.703] [info] node id:24 Process node end\n",
-            "[2023-07-11 08:06:51.705] [info] node id:24 close node\n",
-            "[2023-07-11 08:06:51.705] [info] node 24 close report, closed count: 2\n",
-            "[2023-07-11 08:06:51.705] [info] node id:29 eof received\n",
-            "[2023-07-11 08:06:51.705] [info] node id:29 eof processed, remove node from scheduler\n",
-            "[2023-07-11 08:06:51.705] [info] node id:29 process eof, add node to scheduler\n",
-            "[2023-07-11 08:06:51.757] [info] node id:29 Process node end\n",
-            "[2023-07-11 08:06:51.758] [info] node id:29 close node\n",
-            "[2023-07-11 08:06:51.758] [info] node 29 close report, closed count: 3\n",
-            "[2023-07-11 08:06:51.758] [info] schedule queue 0 start to join thread\n",
-            "[2023-07-11 08:06:51.758] [info] schedule queue 0 thread quit\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[aac @ 0x7f3600163d00] Qavg: 36541.152\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "[2023-07-11 08:06:51.758] [info] schedule queue 0 closed\n",
-            "[2023-07-11 08:06:51.758] [info] schedule queue 1 start to join thread\n",
-            "[2023-07-11 08:06:51.758] [info] schedule queue 1 thread quit\n",
-            "[2023-07-11 08:06:51.758] [info] schedule queue 1 closed\n",
-            "[2023-07-11 08:06:51.758] [info] all scheduling threads were joint\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -1820,43 +429,10 @@
         "! rm -rf with_null_audio.wav"
       ],
       "metadata": {
-        "id": "3SfQ0jyVlFyR",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "7522b4b5-f079-4b71-e5bb-11a92f6cc263"
+        "id": "3SfQ0jyVlFyR"
       },
-      "execution_count": 25,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "ffprobe version 4.2.7-0ubuntu0.1 Copyright (c) 2007-2022 the FFmpeg developers\n",
-            "  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)\n",
-            "  configuration: --prefix=/usr --extra-version=0ubuntu0.1 --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu --incdir=/usr/include/x86_64-linux-gnu --arch=amd64 --enable-gpl --disable-stripping --enable-avresample --disable-filter=resample --enable-avisynth --enable-gnutls --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libjack --enable-libmp3lame --enable-libmysofa --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse --enable-librsvg --enable-librubberband --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libssh --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwavpack --enable-libwebp --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzmq --enable-libzvbi --enable-lv2 --enable-omx --enable-openal --enable-opencl --enable-opengl --enable-sdl2 --enable-libdc1394 --enable-libdrm --enable-libiec61883 --enable-nvenc --enable-chromaprint --enable-frei0r --enable-libx264 --enable-shared\n",
-            "  libavutil      56. 31.100 / 56. 31.100\n",
-            "  libavcodec     58. 54.100 / 58. 54.100\n",
-            "  libavformat    58. 29.100 / 58. 29.100\n",
-            "  libavdevice    58.  8.100 / 58.  8.100\n",
-            "  libavfilter     7. 57.100 /  7. 57.100\n",
-            "  libavresample   4.  0.  0 /  4.  0.  0\n",
-            "  libswscale      5.  5.100 /  5.  5.100\n",
-            "  libswresample   3.  5.100 /  3.  5.100\n",
-            "  libpostproc    55.  5.100 / 55.  5.100\n",
-            "Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'with_null_audio.wav':\n",
-            "  Metadata:\n",
-            "    major_brand     : isom\n",
-            "    minor_version   : 512\n",
-            "    compatible_brands: isomiso2mp41\n",
-            "    encoder         : Lavf58.29.100\n",
-            "  Duration: 00:00:22.03, start: 0.000000, bitrate: 62 kb/s\n",
-            "    Stream #0:0(und): Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 60 kb/s (default)\n",
-            "    Metadata:\n",
-            "      handler_name    : SoundHandler\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -1879,7 +455,7 @@
         "streams = graph.decode({\n",
         "    \"input_path\": input_video_path,\n",
         "})\n",
-        "video = streams['video'].ff_filter(\"blackframe\", threshold=32).ff_filter(\"metadata\", \"select:key=lavfi.blackframe.pblack:value=96:function=less\")\n",
+        "video = streams['video'].ff_filter(\"blackframe\", threshold=32).ff_filter(\"metadata\", \"select:key=lavfi.blackframe.pblack:value=100:function=less\")\n",
         "vframes_num = 2\n",
         "result = (\n",
         "    bmf.encode(\n",
@@ -1910,102 +486,10 @@
         "            f.write(data)"
       ],
       "metadata": {
-        "id": "AUcjjyR5WM25",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "2491a089-62ed-4d8b-a647-1c9df224b6eb"
+        "id": "AUcjjyR5WM25"
       },
-      "execution_count": 26,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "[2023-07-11 08:08:16.110] [info] Constructing c++ module\n",
-            "[2023-07-11 08:08:16.127] [info] c++ module constructed\n",
-            "[2023-07-11 08:08:16.127] [info] Constructing c++ module\n",
-            "[2023-07-11 08:08:16.127] [info] c++ module constructed\n",
-            "[2023-07-11 08:08:16.127] [info] Constructing c++ module\n",
-            "[2023-07-11 08:08:16.127] [info] c++ module constructed\n",
-            "[2023-07-11 08:08:16.127] [info] Constructing c++ module\n",
-            "[2023-07-11 08:08:16.127] [error] node id:33 No output path\n",
-            "[2023-07-11 08:08:16.127] [info] c++ module constructed\n",
-            "[2023-07-11 08:08:16.127] [info] BMF Version: 0.0.5\n",
-            "[2023-07-11 08:08:16.127] [info] BMF Commit: 98e17ef\n",
-            "[2023-07-11 08:08:16.127] [info] start init graph\n",
-            "[2023-07-11 08:08:16.127] [info] scheduler count2\n",
-            "debug queue size, node 30, queue size: 5\n",
-            "[2023-07-11 08:08:16.127] [info] node:c_ffmpeg_decoder 30 scheduler 0\n",
-            "debug queue size, node 33, queue size: 5\n",
-            "[2023-07-11 08:08:16.127] [info] node:c_ffmpeg_encoder 33 scheduler 1\n",
-            "debug queue size, node 31, queue size: 5\n",
-            "[2023-07-11 08:08:16.127] [info] Constructing c++ module\n",
-            "[2023-07-11 08:08:16.127] [info] c++ module constructed\n",
-            "[2023-07-11 08:08:16.127] [info] node:c_ffmpeg_filter 31 scheduler 0\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "Input #0, mov,mp4,m4a,3gp,3g2,mj2, from './big_bunny_10s_30fps.mp4':\n",
-            "  Metadata:\n",
-            "    major_brand     : isom\n",
-            "    minor_version   : 512\n",
-            "    compatible_brands: isomiso2avc1mp41\n",
-            "    encoder         : Lavf58.76.100\n",
-            "  Duration: 00:00:10.00, start: 0.000000, bitrate: 2044 kb/s\n",
-            "    Stream #0:0(und): Video: h264 (High) (avc1 / 0x31637661), yuv420p, 1920x1080 [SAR 1:1 DAR 16:9], 1904 kb/s, 30 fps, 30 tbr, 15360 tbn, 60 tbc (default)\n",
-            "    Metadata:\n",
-            "      handler_name    : VideoHandler\n",
-            "    Stream #0:1(und): Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 129 kb/s (default)\n",
-            "    Metadata:\n",
-            "      handler_name    : SoundHandler\n",
-            "[Parsed_blackframe_0 @ 0x7f3604af2f40] frame:0 pblack:100 pts:0 t:0.000000 type:? last_keyframe:0\n",
-            "[Parsed_blackframe_0 @ 0x7f3604af2f40] frame:1 pblack:100 pts:512 t:0.033333 type:? last_keyframe:0\n",
-            "[Parsed_blackframe_0 @ 0x7f3604af2f40] frame:2 pblack:100 pts:1024 t:0.066667 type:? last_keyframe:0\n",
-            "[Parsed_blackframe_0 @ 0x7f3604af2f40] frame:3 pblack:100 pts:1536 t:0.100000 type:? last_keyframe:0\n",
-            "Output #0, image2pipe, to '':\n",
-            "  Metadata:\n",
-            "    encoder         : Lavf58.29.100\n",
-            "    Stream #0:0: Video: mjpeg, yuvj444p(pc), 640x480 [SAR 1:1 DAR 4:3], q=2-31, 30 fps, 30 tbr, 30 tbn, 30 tbc\n",
-            "[swscaler @ 0x7f360027d840] deprecated pixel format used, make sure you did set range correctly\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "[2023-07-11 08:08:16.265] [info] *** 1 dup!\n",
-            "[2023-07-11 08:08:20.081] [info] node id:30 decode flushing\n",
-            "[2023-07-11 08:08:20.081] [info] node id:30 Process node end\n",
-            "[2023-07-11 08:08:20.091] [info] node id:30 close node\n",
-            "[2023-07-11 08:08:20.091] [info] node 30 close report, closed count: 1\n",
-            "[2023-07-11 08:08:20.091] [info] node id:31 eof received\n",
-            "[2023-07-11 08:08:20.091] [info] node id:31 eof processed, remove node from scheduler\n",
-            "[2023-07-11 08:08:20.101] [info] node id:31 process eof, add node to scheduler\n",
-            "[2023-07-11 08:08:20.127] [info] node id:31 Process node end\n",
-            "[2023-07-11 08:08:20.136] [info] node id:31 close node\n",
-            "[2023-07-11 08:08:20.139] [info] node 31 close report, closed count: 2\n",
-            "[2023-07-11 08:08:20.140] [info] node id:33 eof received\n",
-            "[2023-07-11 08:08:20.141] [info] node id:33 eof processed, remove node from scheduler\n",
-            "[2023-07-11 08:08:20.141] [info] node id:33 process eof, add node to scheduler\n",
-            "[2023-07-11 08:08:20.141] [info] *** dropping frame 2 at ts 2048\n",
-            "[2023-07-11 08:08:20.141] [info] node id:33 Process node end\n",
-            "[2023-07-11 08:08:20.141] [info] node id:33 close node\n",
-            "[2023-07-11 08:08:20.141] [info] node 33 close report, closed count: 3\n",
-            "[2023-07-11 08:08:20.141] [info] node id:-1 eof received\n",
-            "[2023-07-11 08:08:20.141] [info] schedule queue 0 start to join thread\n",
-            "[2023-07-11 08:08:20.142] [info] schedule queue 0 thread quit\n",
-            "[2023-07-11 08:08:20.142] [info] schedule queue 0 closed\n",
-            "[2023-07-11 08:08:20.142] [info] schedule queue 1 start to join thread\n",
-            "[2023-07-11 08:08:20.142] [info] schedule queue 1 thread quit\n",
-            "[2023-07-11 08:08:20.142] [info] schedule queue 1 closed\n",
-            "[2023-07-11 08:08:20.142] [info] all scheduling threads were joint\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
@@ -2014,36 +498,10 @@
         "! rm -rf simple_image*.jpg"
       ],
       "metadata": {
-        "id": "xmW17RiI-Fid",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "cd83b586-0cd3-4106-c8ce-298cff5b4e2d"
+        "id": "xmW17RiI-Fid"
       },
-      "execution_count": 27,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "ffprobe version 4.2.7-0ubuntu0.1 Copyright (c) 2007-2022 the FFmpeg developers\n",
-            "  built with gcc 9 (Ubuntu 9.4.0-1ubuntu1~20.04.1)\n",
-            "  configuration: --prefix=/usr --extra-version=0ubuntu0.1 --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu --incdir=/usr/include/x86_64-linux-gnu --arch=amd64 --enable-gpl --disable-stripping --enable-avresample --disable-filter=resample --enable-avisynth --enable-gnutls --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libjack --enable-libmp3lame --enable-libmysofa --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse --enable-librsvg --enable-librubberband --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libssh --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwavpack --enable-libwebp --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzmq --enable-libzvbi --enable-lv2 --enable-omx --enable-openal --enable-opencl --enable-opengl --enable-sdl2 --enable-libdc1394 --enable-libdrm --enable-libiec61883 --enable-nvenc --enable-chromaprint --enable-frei0r --enable-libx264 --enable-shared\n",
-            "  libavutil      56. 31.100 / 56. 31.100\n",
-            "  libavcodec     58. 54.100 / 58. 54.100\n",
-            "  libavformat    58. 29.100 / 58. 29.100\n",
-            "  libavdevice    58.  8.100 / 58.  8.100\n",
-            "  libavfilter     7. 57.100 /  7. 57.100\n",
-            "  libavresample   4.  0.  0 /  4.  0.  0\n",
-            "  libswscale      5.  5.100 /  5.  5.100\n",
-            "  libswresample   3.  5.100 /  3.  5.100\n",
-            "  libpostproc    55.  5.100 / 55.  5.100\n",
-            "Input #0, image2, from 'simple_image0.jpg':\n",
-            "  Duration: 00:00:00.04, start: 0.000000, bitrate: 3240 kb/s\n",
-            "    Stream #0:0: Video: mjpeg (Baseline), yuvj444p(pc, bt470bg/unknown/unknown), 640x480 [SAR 1:1 DAR 4:3], 25 tbr, 25 tbn, 25 tbc\n"
-          ]
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     }
   ]
 }


### PR DESCRIPTION
1. 修复 apt 安装 libavxxx-dev 可能失败的问题；
2. 修复 colab 子进程执行 shell 导致的 cd 命令失效问题；
3. 调整图片 demo 中黑帧检测阈值，96->100；