### PR TITLE
Add missing headers

### DIFF
--- a/bmf/engine/connector/internal/instance_mapping.hpp
+++ b/bmf/engine/connector/internal/instance_mapping.hpp
@@ -8,6 +8,7 @@
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
+#include <stdexcept>
 
 namespace bmf::internal {
 template <typename T> class InstanceMapping {

--- a/bmf/sdk/cpp_sdk/include/bmf/sdk/log_buffer.h
+++ b/bmf/sdk/cpp_sdk/include/bmf/sdk/log_buffer.h
@@ -23,6 +23,7 @@
 #include <mutex>
 #include <map>
 #include <vector>
+#include <string>
 
 BEGIN_BMF_SDK_NS
 


### PR DESCRIPTION
There are some missing STL headers causing undefined symbol for some compiler / STL version.