### PR TITLE
Use mutable lambda

### DIFF
--- a/bmf/python/py_module_sdk.cpp
+++ b/bmf/python/py_module_sdk.cpp
@@ -566,7 +566,7 @@ void module_sdk_bind(py::module &m) {
     py::class_<LogBuffer, std::unique_ptr<LogBuffer>>(m, "LogBuffer")
         .def(py::init([](py::list buffer, const std::string &level) {
             return std::make_unique<LogBuffer>(
-                [=](const std::string &log) {
+                [buffer](const std::string &log) mutable {
                     py::gil_scoped_acquire gil;
                     buffer.append(py::cast(log));
                 },


### PR DESCRIPTION
py::list::append is non-const, but non-mutable lambda's call operator is const, therefore cannot call the non-const method on copy-captured object.

Note: py::list itself is a referencing-count wrapper of the underlying Python object so copy-capture is correct here.

