### PR TITLE
Fix segfault memleak GitHub

### DIFF
--- a/bmf/hml/src/cuda/cuda_allocator.cpp
+++ b/bmf/hml/src/cuda/cuda_allocator.cpp
@@ -210,16 +210,17 @@ class CUDAAllocator : public Allocator {
             freed_.push_back(std::make_pair(event, it->second));
             it->second->event_count += 1;
         }
+        Block* b = it->second;
         alloced_.erase(it);
-        it->second->allocated = false;
-        it->second->streams.clear();
+        b->allocated = false;
+        b->streams.clear();
 
-        update_stat(stats_.active, -it->second->size);
+        update_stat(stats_.active, -b->size);
 
-        if (it->second->event_count == 0) {
-            free_block(it->second);
+        if (b->event_count == 0) {
+            free_block(b);
         } else {
-            update_stat(stats_.inactive, it->second->size);
+            update_stat(stats_.inactive, b->size);
         }
 
         process_events();

--- a/bmf/python/py_module_sdk.cpp
+++ b/bmf/python/py_module_sdk.cpp
@@ -380,7 +380,8 @@ void module_sdk_bind(py::module &m) {
              (VideoFrame(VideoFrame::*)(const Device &, bool) const) &
                  VideoFrame::to,
              py::arg("device"), py::arg("non_blocking") = false)
-        .def("copy_props", &VideoFrame::copy_props, py::arg("from"))
+        .def("copy_props", &VideoFrame::copy_props, py::arg("from"),
+             py::arg("copy_private") = false)
         .def("reformat", &VideoFrame::reformat, py::arg("pix_info"));
     PACKET_REGISTER_BMF_SDK_TYPE(VideoFrame)
 

--- a/bmf/sdk/cpp_sdk/include/bmf/sdk/video_frame.h
+++ b/bmf/sdk/cpp_sdk/include/bmf/sdk/video_frame.h
@@ -187,7 +187,7 @@ class BMF_API VideoFrame : public OpaqueDataSet,
      * @param from
      * @return VideoFrame&
      */
-    VideoFrame &copy_props(const VideoFrame &from);
+    VideoFrame &copy_props(const VideoFrame &from, bool copy_private = false);
 
   protected:
     VideoFrame(const std::shared_ptr<Private> &other);

--- a/bmf/sdk/cpp_sdk/src/video_frame.cpp
+++ b/bmf/sdk/cpp_sdk/src/video_frame.cpp
@@ -92,8 +92,11 @@ VideoFrame VideoFrame::to(const Device &device, bool non_blocking) const {
     return vf;
 }
 
-VideoFrame &VideoFrame::copy_props(const VideoFrame &from) {
-    //OpaqueDataSet::copy_props(from);
+VideoFrame &VideoFrame::copy_props(const VideoFrame &from, bool copy_private) {
+    if (copy_private) {
+        OpaqueDataSet::copy_props(from);
+    }
+
     SequenceData::copy_props(from);
     Future::copy_props(from);
     return *this;

--- a/bmf/sdk/cpp_sdk/src/video_frame.cpp
+++ b/bmf/sdk/cpp_sdk/src/video_frame.cpp
@@ -93,7 +93,7 @@ VideoFrame VideoFrame::to(const Device &device, bool non_blocking) const {
 }
 
 VideoFrame &VideoFrame::copy_props(const VideoFrame &from) {
-    OpaqueDataSet::copy_props(from);
+    //OpaqueDataSet::copy_props(from);
     SequenceData::copy_props(from);
     Future::copy_props(from);
     return *this;


### PR DESCRIPTION
- Fix segment fault caused by using an iterator after erasing.
- Fix memory leaks due to incorrect management of framesctx references.
- By default, do not copy `private_data` when copying frames, as it may affect subsequent conversions with AVFrame. 