### PR TITLE
Add BGR support in bmf.convert

### DIFF
--- a/bmf/hml/include/hmp/imgproc.h
+++ b/bmf/hml/include/hmp/imgproc.h
@@ -40,11 +40,23 @@ HMP_API Tensor &yuv_to_rgb(Tensor &dst, const TensorList &src,
                            ChannelFormat cformat = kNCHW);
 HMP_API Tensor yuv_to_rgb(const TensorList &src, const PixelInfo &pix_info,
                           ChannelFormat cformat = kNCHW);
+HMP_API Tensor &yuv_to_bgr(Tensor &dst, const TensorList &src,
+                           const PixelInfo &pix_info,
+                           ChannelFormat cformat = kNCHW);
+HMP_API Tensor yuv_to_bgr(const TensorList &src,
+                          const PixelInfo &pix_info,
+                          ChannelFormat cformat = kNCHW);
 
 HMP_API TensorList &rgb_to_yuv(TensorList &dst, const Tensor &src,
                                const PixelInfo &pix_info,
                                ChannelFormat cformat = kNCHW);
 HMP_API TensorList rgb_to_yuv(const Tensor &src, const PixelInfo &pix_info,
+                              ChannelFormat cformat = kNCHW);
+HMP_API TensorList &bgr_to_yuv(TensorList &dst, const Tensor &src,
+                               const PixelInfo &pix_info,
+                               ChannelFormat cformat = kNCHW);
+HMP_API TensorList bgr_to_yuv(const Tensor &src,
+                              const PixelInfo &pix_info,
                               ChannelFormat cformat = kNCHW);
 
 HMP_API TensorList &yuv_to_yuv(TensorList &dst, const TensorList &src,

--- a/bmf/hml/include/hmp/imgproc/formats.h
+++ b/bmf/hml/include/hmp/imgproc/formats.h
@@ -111,6 +111,7 @@ enum PixelFormat {
     PF_YUVA420P = 33,
     PF_RGB48 = 35,
     PF_YA8 = 58,
+    PF_BGR48 = 61,
     PF_RGBA64 = 107,
 
     PF_P010LE = 161,
@@ -291,5 +292,13 @@ class HMP_API PixelFormatDesc {
     int pix_format_ = PF_NONE;
     const Private *meta_ = nullptr;
 };
+
+enum class RGBFormat : uint8_t  {
+    RGB,
+    BGR,
+};
+
+const static RGBFormat kRGB = RGBFormat::RGB;
+const static RGBFormat kBGR = RGBFormat::BGR;
 
 } // namespace hmp

--- a/bmf/hml/src/imgproc/image.cpp
+++ b/bmf/hml/src/imgproc/image.cpp
@@ -174,7 +174,12 @@ Frame Frame::reformat(const PixelInfo &pix_info) {
         Frame frame(width_, height_, pix_info, device());
         auto yuv = img::rgb_to_yuv(frame.data(), data_[0], pix_info, kNHWC);
         return frame;
-
+    } else if (pix_info_.format() == PF_BGR24 || pix_info_.format() == PF_BGR48) {
+        auto yuv = img::bgr_to_yuv(data_[0], pix_info, kNHWC);
+        return Frame(yuv, width_, height_, pix_info);
+    } else if (pix_info.format() == PF_BGR24 || pix_info.format() == PF_BGR48) {
+        auto rgb = img::yuv_to_bgr(data_, pix_info_, kNHWC);
+        return Frame({rgb}, width_, height_, pix_info);
     } else if (pix_info.format() == PF_RGB24 || pix_info.format() == PF_RGB48) {
         auto rgb = img::yuv_to_rgb(data_, pix_info_, kNHWC);
         return Frame({rgb}, width_, height_, pix_info);

--- a/bmf/hml/src/kernel/cuda/imgproc.cu
+++ b/bmf/hml/src/kernel/cuda/imgproc.cu
@@ -15,10 +15,10 @@ namespace{
 
 
 // scalar_t, dst, src, batch, width, height need pre-defined
-#define PIXEL_FORMAT_CASE(Op, Format, Cformat)                                                  \
+#define PIXEL_FORMAT_CASE(Op, Format, Cformat, Bgr)                                                  \
     case(PPixelFormat::Format):                                                                  \
         do{                                                                                     \
-            Op<scalar_t, PPixelFormat::Format, Cformat> op(dst, src);                            \
+            Op<scalar_t, PPixelFormat::Format, Cformat, Bgr> op(dst, src);                            \
             cuda::invoke_img_elementwise_kernel([=]HMP_HOST_DEVICE(int batch, int w, int h) mutable{\
                 op(batch, w, h);                                                                \
             }, batch, width, height);                                                           \
@@ -26,28 +26,28 @@ namespace{
         break;
 
 
-#define PIXEL_FORMAT_DISPATCH(Op, format, Cformat, name)                                        \
+#define PIXEL_FORMAT_DISPATCH(Op, format, Cformat, name, bgr)                                        \
     switch(format){                                                                             \
-        PIXEL_FORMAT_CASE(Op, H420, Cformat)                                                   \
-        PIXEL_FORMAT_CASE(Op, H422, Cformat)                                                   \
-        PIXEL_FORMAT_CASE(Op, H444, Cformat)                                                   \
-        PIXEL_FORMAT_CASE(Op, I420, Cformat)                                                   \
-        PIXEL_FORMAT_CASE(Op, I422, Cformat)                                                   \
-        PIXEL_FORMAT_CASE(Op, I444, Cformat)                                                   \
-        PIXEL_FORMAT_CASE(Op, NV21, Cformat)                                                   \
-        PIXEL_FORMAT_CASE(Op, NV12, Cformat)                                                   \
-        PIXEL_FORMAT_CASE(Op, NV21_BT709, Cformat)                                                   \
-        PIXEL_FORMAT_CASE(Op, NV12_BT709, Cformat)                                                   \
-        PIXEL_FORMAT_CASE(Op, U420, Cformat)                                                   \
-        PIXEL_FORMAT_CASE(Op, U422, Cformat)                                                   \
-        PIXEL_FORMAT_CASE(Op, U444, Cformat)                                                   \
-        PIXEL_FORMAT_CASE(Op, P010, Cformat)                                                   \
+        PIXEL_FORMAT_CASE(Op, H420, Cformat, bgr)                                                   \
+        PIXEL_FORMAT_CASE(Op, H422, Cformat, bgr)                                                   \
+        PIXEL_FORMAT_CASE(Op, H444, Cformat, bgr)                                                   \
+        PIXEL_FORMAT_CASE(Op, I420, Cformat, bgr)                                                   \
+        PIXEL_FORMAT_CASE(Op, I422, Cformat, bgr)                                                   \
+        PIXEL_FORMAT_CASE(Op, I444, Cformat, bgr)                                                   \
+        PIXEL_FORMAT_CASE(Op, NV21, Cformat, bgr)                                                   \
+        PIXEL_FORMAT_CASE(Op, NV12, Cformat, bgr)                                                   \
+        PIXEL_FORMAT_CASE(Op, NV21_BT709, Cformat, bgr)                                                   \
+        PIXEL_FORMAT_CASE(Op, NV12_BT709, Cformat, bgr)                                                   \
+        PIXEL_FORMAT_CASE(Op, U420, Cformat, bgr)                                                   \
+        PIXEL_FORMAT_CASE(Op, U422, Cformat, bgr)                                                   \
+        PIXEL_FORMAT_CASE(Op, U444, Cformat, bgr)                                                   \
+        PIXEL_FORMAT_CASE(Op, P010, Cformat, bgr)                                                   \
         default:                                                                                \
             HMP_REQUIRE(false, "{} : unsupported PPixelFormat {}", name, format);                \
      }
 
 
-Tensor &yuv_to_rgb_cuda(Tensor &dst, const TensorList &src, PPixelFormat format, ChannelFormat cformat)
+Tensor &yuv_to_rgb_cuda(Tensor &dst, const TensorList &src, PPixelFormat format, ChannelFormat cformat, PixelFormat rgbformat)
 {
     auto batch = src[0].size(0);
     auto height = src[0].size(1);
@@ -55,32 +55,59 @@ Tensor &yuv_to_rgb_cuda(Tensor &dst, const TensorList &src, PPixelFormat format,
 
     HMP_DISPATCH_IMAGE_TYPES_AND_HALF(src[0].scalar_type(), "yuv_to_rgb_cuda", [&](){
         if(cformat == kNCHW){
-            PIXEL_FORMAT_DISPATCH(YUV2RGB, format, kNCHW, "yuv_to_rgb_cuda");
+            switch(rgbformat) {
+                case PF_RGB24:
+                case PF_RGB48:
+                PIXEL_FORMAT_DISPATCH(YUV2RGB, format, kNCHW, "yuv_to_rgb_cuda", kRGB);
+                break;
+
+                case PF_BGR24:
+                case PF_BGR48:
+                PIXEL_FORMAT_DISPATCH(YUV2RGB, format, kNCHW, "yuv_to_rgb_cuda", kBGR);
+                break;
+
+                default:
+                HMP_REQUIRE(false, "Unsupported RGB PixelFormat {}", rgbformat);
+            }
         }
         else{
-            PIXEL_FORMAT_DISPATCH(YUV2RGB, format, ChannelFormat::NHWC, "yuv_to_rgb_cuda");
+            // PIXEL_FORMAT_DISPATCH(YUV2RGB, format, ChannelFormat::NHWC, "yuv_to_rgb_cuda", BGR);
+            switch(rgbformat) {
+                case PF_RGB24:
+                case PF_RGB48:
+                PIXEL_FORMAT_DISPATCH(YUV2RGB, format, ChannelFormat::NHWC, "yuv_to_rgb_cuda", kRGB);
+                break;
+
+                case PF_BGR24:
+                case PF_BGR48:
+                PIXEL_FORMAT_DISPATCH(YUV2RGB, format, ChannelFormat::NHWC, "yuv_to_rgb_cuda", kBGR);
+                break;
+
+                default:
+                HMP_REQUIRE(false, "Unsupported RGB PixelFormat {}", rgbformat);
+            }
         }
     });
- 
+
     return dst;
 }
 
 
 
-TensorList &rgb_to_yuv_cuda(TensorList &dst, const Tensor &src, PPixelFormat format, ChannelFormat cformat)
+TensorList &rgb_to_yuv_cuda(TensorList &dst, const Tensor &src, PPixelFormat format, ChannelFormat cformat, PixelFormat rgbformat)
 {
-    auto batch = dst[0].size(0);
-    auto height = dst[0].size(1);
-    auto width = dst[0].size(2);
+    // auto batch = dst[0].size(0);
+    // auto height = dst[0].size(1);
+    // auto width = dst[0].size(2);
 
-    HMP_DISPATCH_IMAGE_TYPES_AND_HALF(dst[0].scalar_type(), "rgb_to_yuv_cuda", [&](){
-        if(cformat == kNCHW){
-            PIXEL_FORMAT_DISPATCH(RGB2YUV, format, kNCHW, "rgb_to_yuv_cuda");
-        }
-        else{
-            PIXEL_FORMAT_DISPATCH(RGB2YUV, format, ChannelFormat::NHWC, "rgb_to_yuv_cuda");
-        }
-    });
+    // HMP_DISPATCH_IMAGE_TYPES_AND_HALF(dst[0].scalar_type(), "rgb_to_yuv_cuda", [&](){
+    //     if(cformat == kNCHW){
+    //         PIXEL_FORMAT_DISPATCH(RGB2YUV, format, kNCHW, "rgb_to_yuv_cuda");
+    //     }
+    //     else{
+    //         PIXEL_FORMAT_DISPATCH(RGB2YUV, format, ChannelFormat::NHWC, "rgb_to_yuv_cuda");
+    //     }
+    // });
  
     return dst;
 }

--- a/bmf/hml/src/kernel/image_color_cvt.h
+++ b/bmf/hml/src/kernel/image_color_cvt.h
@@ -15,15 +15,54 @@
  */
 #pragma once
 
+#include <limits>
+
 #include <hmp/imgproc.h>
 #include <kernel/image_iter.h>
 
 namespace hmp {
 namespace kernel {
 
-template <typename T, PPixelFormat format, ChannelFormat cformat>
+// template <typename T>
+union RGB {
+    // RGB24() {c.r = 0; c.g = 0; c.b = 0;}
+    Vector<float, 3> v;
+    struct {
+        float r = 0, g = 0, b = 0;
+    } c;
+};
+
+// template <typename T>
+union BGR {
+    // BGR24() {b = 0; g = 0; r = 0;}
+    Vector<float, 3> v;
+    
+    struct {
+        float b = 0, g = 0, r = 0;
+    } c;
+};
+
+// template <typename T>
+union RGBA {
+    // RGBA24() {r = 0; g = 0; b = 0; a = std::numeric_limits<float>::max();}
+    Vector<float, 4> v;
+    struct {
+        float r, g, b, a;
+    } c;
+};
+
+// template <typename T>
+union BGRA {
+    // BGRA24() {b = 0; g = 0; r = 0; a = std::numeric_limits<float>::max();}
+    Vector<float, 4> v;
+    struct {
+        float b, g, r, a;
+    } c;
+};
+
+template <typename T, PPixelFormat format, ChannelFormat cformat, RGBFormat rformat>
 struct YUV2RGB {
-    RGBIter<T, cformat> rgb_iter;
+    RGBIter<T, cformat, rformat> rgb_iter;
     YUVIter<T, format> yuv_iter;
     using wtype = Vector<float, 3>;
     using otype = Vector<T, 3>;
@@ -41,6 +80,7 @@ struct YUV2RGB {
     HMP_HOST_DEVICE inline void operator()(int batch, int w, int h) {
         wtype yuv = yuv_iter.get(batch, w, h);
         wtype rgb(0, 0, 0);
+        // RGB_t rgb{};
 
         // FIXME: only support 8bit pixel data
 
@@ -81,9 +121,9 @@ struct YUV2RGB {
     }
 };
 
-template <typename T, PPixelFormat format, ChannelFormat cformat>
+template <typename T, PPixelFormat format, ChannelFormat cformat, RGBFormat rformat>
 struct RGB2YUV {
-    RGBIter<T, cformat> rgb_iter;
+    RGBIter<T, cformat, rformat> rgb_iter;
     YUVIter<T, format> yuv_iter;
     using wtype = Vector<float, 3>;
     using otype = Vector<T, 3>;

--- a/bmf/hml/src/kernel/image_color_cvt.h
+++ b/bmf/hml/src/kernel/image_color_cvt.h
@@ -23,43 +23,6 @@
 namespace hmp {
 namespace kernel {
 
-// template <typename T>
-union RGB {
-    // RGB24() {c.r = 0; c.g = 0; c.b = 0;}
-    Vector<float, 3> v;
-    struct {
-        float r = 0, g = 0, b = 0;
-    } c;
-};
-
-// template <typename T>
-union BGR {
-    // BGR24() {b = 0; g = 0; r = 0;}
-    Vector<float, 3> v;
-    
-    struct {
-        float b = 0, g = 0, r = 0;
-    } c;
-};
-
-// template <typename T>
-union RGBA {
-    // RGBA24() {r = 0; g = 0; b = 0; a = std::numeric_limits<float>::max();}
-    Vector<float, 4> v;
-    struct {
-        float r, g, b, a;
-    } c;
-};
-
-// template <typename T>
-union BGRA {
-    // BGRA24() {b = 0; g = 0; r = 0; a = std::numeric_limits<float>::max();}
-    Vector<float, 4> v;
-    struct {
-        float b, g, r, a;
-    } c;
-};
-
 template <typename T, PPixelFormat format, ChannelFormat cformat, RGBFormat rformat>
 struct YUV2RGB {
     RGBIter<T, cformat, rformat> rgb_iter;

--- a/bmf/hml/src/kernel/image_iter.h
+++ b/bmf/hml/src/kernel/image_iter.h
@@ -277,21 +277,6 @@ template <typename Pixel, ChannelFormat CFormat, RGBFormat RFormat = kRGB> struc
 template <typename Pixel, ChannelFormat CFormat>
 struct RGBSeqIter<Pixel, CFormat, kRGB> : public ImageSeqIter<Pixel, CFormat> {
     using ImageSeqIter<Pixel, CFormat>::ImageSeqIter;
-
-    // HMP_HOST_DEVICE inline Pixel get(int batch, int x, int y) const {
-    //     Pixel pix;
-    //     pix = ImageSeqIter<Pixel, CFormat>::get(batch, x, y);
-
-    //     std::swap(pix[0], pix[1]);
-    //     return pix;
-    // }
-
-    // HMP_HOST_DEVICE inline void set(int batch, int x, int y,
-    //                                 const Pixel &pix) const {
-    //     // std::swap(pix[0], pix[1]);
-    //     Pixel p_{pix[2], pix[1], pix[0]};
-    //     ImageSeqIter<Pixel, CFormat>::set(batch, x, y, p_);
-    // }
 };
 
 template <typename Pixel, ChannelFormat CFormat>
@@ -308,7 +293,6 @@ struct RGBSeqIter<Pixel, CFormat, kBGR> : public ImageSeqIter<Pixel, CFormat> {
 
     HMP_HOST_DEVICE inline void set(int batch, int x, int y,
                                     const Pixel &pix) const {
-        // std::swap(pix[0], pix[1]);
         Pixel p_{pix[2], pix[1], pix[0]};
         ImageSeqIter<Pixel, CFormat>::set(batch, x, y, p_);
     }
@@ -319,60 +303,6 @@ struct RGBSeqIter<Pixel, CFormat, kBGR> : public ImageSeqIter<Pixel, CFormat> {
 
 template <typename T, ChannelFormat cformat, RGBFormat rformat = kRGB, int C = 3>
 using RGBIter = RGBSeqIter<Vector<T, C>, cformat, rformat>;
-
-// template <typename T, ChannelFormat cformat, 3, RGBFormat::kRGB>
-// using RGBIter = ImageSeqIter<Vector<T, C>, cformat>;
-
-// template <typename T, ChannelFormat cformat, int C = 4, RGBFormat rformat = RGBFormat::kRGBA>
-// using RGBIter = ImageSeqIter<Vector<T, C>, cformat>;
-
-// template <typename T, ChannelFormat cformat, int C = 3, RGBFormat rformat = RGBFormat::kBGR>
-// using RGBIter = ImageSeqIter<Vector<T, C>, cformat> {
-//     // using ImageSeqIter::ImageSeqIter;
-
-//     HMP_HOST_DEVICE inline Pixel get(int batch, int x, int y) const {
-//         Pixel pix;
-//         if (border_ == kBReplicate) {
-//             x = clamp(x, 0, width_ - 1);
-//             y = clamp(y, 0, height_ - 1);
-
-//             auto idx = index(batch, x, y);
-// #pragma unroll
-//             for (int i = 0; i < Pixel::size(); ++i) {
-//                 pix[i] = ptr_[i][idx];
-//             }
-//         } else {
-//             if (x < 0 || x >= width_ || y < 0 || y >= height_) {
-//                 pix = DefaultPixelValue<Pixel>::value();
-//             } else {
-//                 auto idx = index(batch, x, y);
-// #pragma unroll
-//                 for (int i = 0; i < Pixel::size(); ++i) {
-//                     pix[i] = ptr_[i][idx];
-//                 }
-//             }
-//         }
-
-//         return pix;
-//     }
-
-//     HMP_HOST_DEVICE inline void set(int batch, int x, int y,
-//                                     const Pixel &pix) const {
-//         if (border_ == kBReplicate) {
-//             x = clamp(x, 0, width_ - 1);
-//             y = clamp(y, 0, height_ - 1);
-//         } else if (x < 0 || x >= width_ || y < 0 || y >= height_) {
-//             return;
-//         }
-
-//         auto idx = index(batch, x, y);
-// #pragma unroll
-//         for (int i = 0; i < Pixel::size(); ++i) {
-//             ptr_[i][idx] = pix[i];
-//         }
-//     }
-
-// };
 
 template <typename T, PPixelFormat format, typename = void> struct YUVIter;
 

--- a/bmf/hml/src/kernel/image_iter.h
+++ b/bmf/hml/src/kernel/image_iter.h
@@ -272,8 +272,107 @@ struct ImageSeqIter<Pixel, kNCHW> : public ImageIndexer<int> {
     typename Pixel::value_type *ptr_[Pixel::size()] = {0};
 };
 
-template <typename T, ChannelFormat cformat, int C = 3>
-using RGBIter = ImageSeqIter<Vector<T, C>, cformat>;
+template <typename Pixel, ChannelFormat CFormat, RGBFormat RFormat = kRGB> struct RGBSeqIter;
+
+template <typename Pixel, ChannelFormat CFormat>
+struct RGBSeqIter<Pixel, CFormat, kRGB> : public ImageSeqIter<Pixel, CFormat> {
+    using ImageSeqIter<Pixel, CFormat>::ImageSeqIter;
+
+    // HMP_HOST_DEVICE inline Pixel get(int batch, int x, int y) const {
+    //     Pixel pix;
+    //     pix = ImageSeqIter<Pixel, CFormat>::get(batch, x, y);
+
+    //     std::swap(pix[0], pix[1]);
+    //     return pix;
+    // }
+
+    // HMP_HOST_DEVICE inline void set(int batch, int x, int y,
+    //                                 const Pixel &pix) const {
+    //     // std::swap(pix[0], pix[1]);
+    //     Pixel p_{pix[2], pix[1], pix[0]};
+    //     ImageSeqIter<Pixel, CFormat>::set(batch, x, y, p_);
+    // }
+};
+
+template <typename Pixel, ChannelFormat CFormat>
+struct RGBSeqIter<Pixel, CFormat, kBGR> : public ImageSeqIter<Pixel, CFormat> {
+    using ImageSeqIter<Pixel, CFormat>::ImageSeqIter;
+
+    HMP_HOST_DEVICE inline Pixel get(int batch, int x, int y) const {
+        Pixel pix;
+        pix = ImageSeqIter<Pixel, CFormat>::get(batch, x, y);
+
+        std::swap(pix[0], pix[1]);
+        return pix;
+    }
+
+    HMP_HOST_DEVICE inline void set(int batch, int x, int y,
+                                    const Pixel &pix) const {
+        // std::swap(pix[0], pix[1]);
+        Pixel p_{pix[2], pix[1], pix[0]};
+        ImageSeqIter<Pixel, CFormat>::set(batch, x, y, p_);
+    }
+};
+
+// template <typename T, ChannelFormat cformat, int C = 3>
+// using RGBIter = ImageSeqIter<Vector<T, C>, cformat>;
+
+template <typename T, ChannelFormat cformat, RGBFormat rformat = kRGB, int C = 3>
+using RGBIter = RGBSeqIter<Vector<T, C>, cformat, rformat>;
+
+// template <typename T, ChannelFormat cformat, 3, RGBFormat::kRGB>
+// using RGBIter = ImageSeqIter<Vector<T, C>, cformat>;
+
+// template <typename T, ChannelFormat cformat, int C = 4, RGBFormat rformat = RGBFormat::kRGBA>
+// using RGBIter = ImageSeqIter<Vector<T, C>, cformat>;
+
+// template <typename T, ChannelFormat cformat, int C = 3, RGBFormat rformat = RGBFormat::kBGR>
+// using RGBIter = ImageSeqIter<Vector<T, C>, cformat> {
+//     // using ImageSeqIter::ImageSeqIter;
+
+//     HMP_HOST_DEVICE inline Pixel get(int batch, int x, int y) const {
+//         Pixel pix;
+//         if (border_ == kBReplicate) {
+//             x = clamp(x, 0, width_ - 1);
+//             y = clamp(y, 0, height_ - 1);
+
+//             auto idx = index(batch, x, y);
+// #pragma unroll
+//             for (int i = 0; i < Pixel::size(); ++i) {
+//                 pix[i] = ptr_[i][idx];
+//             }
+//         } else {
+//             if (x < 0 || x >= width_ || y < 0 || y >= height_) {
+//                 pix = DefaultPixelValue<Pixel>::value();
+//             } else {
+//                 auto idx = index(batch, x, y);
+// #pragma unroll
+//                 for (int i = 0; i < Pixel::size(); ++i) {
+//                     pix[i] = ptr_[i][idx];
+//                 }
+//             }
+//         }
+
+//         return pix;
+//     }
+
+//     HMP_HOST_DEVICE inline void set(int batch, int x, int y,
+//                                     const Pixel &pix) const {
+//         if (border_ == kBReplicate) {
+//             x = clamp(x, 0, width_ - 1);
+//             y = clamp(y, 0, height_ - 1);
+//         } else if (x < 0 || x >= width_ || y < 0 || y >= height_) {
+//             return;
+//         }
+
+//         auto idx = index(batch, x, y);
+// #pragma unroll
+//         for (int i = 0; i < Pixel::size(); ++i) {
+//             ptr_[i][idx] = pix[i];
+//         }
+//     }
+
+// };
 
 template <typename T, PPixelFormat format, typename = void> struct YUVIter;
 

--- a/bmf/hml/src/kernel/imgproc.cpp
+++ b/bmf/hml/src/kernel/imgproc.cpp
@@ -111,7 +111,7 @@ static inline void yuv_common_check(const TensorList &dst,
 } // namespace
 
 Tensor &yuv_to_rgb(Tensor &dst, const TensorList &src, PPixelFormat pformat,
-                   ChannelFormat cformat) {
+                   ChannelFormat cformat, PixelFormat rformat) {
     auto stmp = img::image_format(src, kNHWC);
     auto dtmp = img::image_format(dst, cformat);
 
@@ -123,14 +123,14 @@ Tensor &yuv_to_rgb(Tensor &dst, const TensorList &src, PPixelFormat pformat,
                 dtmp.size(cdim));
 
     //
-    yuv_to_rgb_stub(dtmp.device_type(), dtmp, stmp, pformat, cformat);
+    yuv_to_rgb_stub(dtmp.device_type(), dtmp, stmp, pformat, cformat, rformat);
     //
 
     return dst;
 }
 
 TensorList &rgb_to_yuv(TensorList &dst, const Tensor &src, PPixelFormat pformat,
-                       ChannelFormat cformat) {
+                       ChannelFormat cformat, PixelFormat rformat) {
     auto stmp = img::image_format(src, cformat);
     auto dtmp = img::image_format(dst, kNHWC);
 
@@ -141,7 +141,7 @@ TensorList &rgb_to_yuv(TensorList &dst, const Tensor &src, PPixelFormat pformat,
                 "rgb_to_yuv: require 3 channels for dst, got {}",
                 stmp.size(cdim));
 
-    rgb_to_yuv_stub(stmp.device_type(), dtmp, stmp, pformat, cformat);
+    rgb_to_yuv_stub(stmp.device_type(), dtmp, stmp, pformat, cformat, rformat);
 
     return dst;
 }

--- a/bmf/hml/src/kernel/imgproc.h
+++ b/bmf/hml/src/kernel/imgproc.h
@@ -55,10 +55,10 @@ namespace kernel {
 
 HMP_DECLARE_DISPATCH_STUB(yuv_to_rgb_stub,
                           Tensor &(*)(Tensor &, const TensorList &,
-                                      PPixelFormat, ChannelFormat));
+                                      PPixelFormat, ChannelFormat, PixelFormat));
 HMP_DECLARE_DISPATCH_STUB(rgb_to_yuv_stub,
                           TensorList &(*)(TensorList &, const Tensor &,
-                                          PPixelFormat, ChannelFormat));
+                                          PPixelFormat, ChannelFormat, PixelFormat));
 HMP_DECLARE_DISPATCH_STUB(yuv_to_yuv_stub,
                           TensorList &(*)(TensorList &, const TensorList &,
                                           PPixelFormat, PPixelFormat));
@@ -114,9 +114,9 @@ HMP_DECLARE_DISPATCH_STUB(img_warp_perspective_stub,
                                       ImageFilterMode, ChannelFormat));
 
 Tensor &yuv_to_rgb(Tensor &dst, const TensorList &src, PPixelFormat pformat,
-                   ChannelFormat cformat);
+                   ChannelFormat cformat, PixelFormat rgbformat);
 TensorList &rgb_to_yuv(TensorList &dst, const Tensor &src, PPixelFormat pformat,
-                       ChannelFormat cformat);
+                       ChannelFormat cformat, PixelFormat rgbformat);
 TensorList &yuv_to_yuv(TensorList &dst, const TensorList &src,
                        PPixelFormat sformat, PPixelFormat dformat);
 


### PR DESCRIPTION
This PR adds BGR support in bmf.convert. The support is implemented by extending hmp::img::yuv_to_rgb and hmp::img::rgb_to_yuv, so tensor::reformat will also support BGR pixel format.

BGRA is not supported as the user can use hmp.tensor to operate on the alpha channel. If BGRA is indeed needed, we can add it in the future.

A script to test the BGR support can be as follows:
```Python
import bmf.hml.hmp as mp
import numpy as np
# from bmf_fixtures import has_cuda, has_torch
from bmf.lib._bmf.sdk import VideoFrame, AudioFrame, BMFAVPacket, MediaDesc, OpaqueDataKey, MediaType, bmf_convert
from bmf.lib._bmf.sdk import Packet
from bmf.lib._bmf import sdk

import torch

H420 = mp.PixelInfo(mp.kPF_YUV420P, mp.kCS_BT709)
vf = VideoFrame(640, 360, pix_info=H420)
vft = [torch.from_dlpack(x) for x in vf.frame().data()]

vft[0][:] = 50
vft[1][:] = 100
vft[2][:] = 150

md = MediaDesc()
md.width(1920).height(1080).pixel_format(mp.kPF_RGB24).device(
    mp.Device("cuda:0"))

dst_vf = bmf_convert(vf, MediaDesc(), md)
assert (dst_vf.width == 1920)
assert (dst_vf.height == 1080)
assert (dst_vf.frame().format() == mp.kPF_RGB24)
assert (dst_vf.frame().device().type() == mp.kCUDA)
assert (dst_vf.frame().device().index() == 0)

dst_t = torch.from_dlpack(dst_vf.frame().data()[0])
print(dst_t[0,0])

md.width(1920).height(1080).pixel_format(mp.kPF_BGR24).device(
    mp.Device("cuda:0"))
dst_bgr = bmf_convert(vf, MediaDesc(), md)
bgr_t = torch.from_dlpack(dst_bgr.frame().data()[0])
print(bgr_t[0,0])

md.pixel_format(mp.kPF_NV12).device(mp.Device("cuda:0"))
dst_420 = bmf_convert(dst_bgr, MediaDesc(), md)
dst_420t = [torch.from_dlpack(x) for x in dst_420.frame().data()]
print(dst_420t[0][0,0], dst_420t[1][0,0])
````