### PR TITLE
Fit colab demos in new env

### DIFF
--- a/bmf/demo/face_detect/facedetect_demo_colab.ipynb
+++ b/bmf/demo/face_detect/facedetect_demo_colab.ipynb
@@ -32,10 +32,10 @@
       "source": [
         "!mkdir -p trt\n",
         "%cd trt\n",
-        "!wget https://developer.nvidia.com/downloads/compute/machine-learning/tensorrt/secure/8.6.1/tars/TensorRT-8.6.1.6.Linux.x86_64-gnu.cuda-11.8.tar.gz\n",
+        "!wget https://developer.nvidia.com/downloads/compute/machine-learning/tensorrt/secure/8.6.1/tars/TensorRT-8.6.1.6.Linux.x86_64-gnu.cuda-12.0.tar.gz\n",
         "%env version=8.6.1.6\n",
         "%env arch=x86_64\n",
-        "%env cuda=cuda-11.8\n",
+        "%env cuda=cuda-12.0\n",
         "!tar -xzvf TensorRT-${version}.Linux.${arch}-gnu.${cuda}.tar.gz\n",
         "!python3 -m pip install --upgrade pip\n",
         "%cd TensorRT-8.6.1.6/python\n",

--- a/bmf/test/customize_module/bmf_customize_demo_latest.ipynb
+++ b/bmf/test/customize_module/bmf_customize_demo_latest.ipynb
@@ -41,7 +41,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install BabitMF==0.0.7"
+        "!pip install BabitMF"
       ]
     },
     {

--- a/bmf/test/sync_mode/bmf_syncmode_cpp.ipynb
+++ b/bmf/test/sync_mode/bmf_syncmode_cpp.ipynb
@@ -54,7 +54,7 @@
     {
       "cell_type": "code",
       "source": [
-        "!pip install BabitMF==0.0.7"
+        "!pip install BabitMF"
       ],
       "metadata": {
         "id": "07aSAmV1OUG_"

--- a/bmf/test/sync_mode/bmf_syncmode_go.ipynb
+++ b/bmf/test/sync_mode/bmf_syncmode_go.ipynb
@@ -54,7 +54,7 @@
     {
       "cell_type": "code",
       "source": [
-        "!pip install BabitMF==0.0.7\n"
+        "!pip install BabitMF\n"
       ],
       "metadata": {
         "id": "KhlymhlIaJm_"


### PR DESCRIPTION
修复 colab 存量问题，统一对齐至最新版本，facedetect demo trt 版本替换为适配 cuda 12.0 的版本