### PR TITLE
fix the incompatibility issue of ffmpeg 5.0 and 5.1

### DIFF
--- a/bmf/c_modules/src/ffmpeg_encoder.cpp
+++ b/bmf/c_modules/src/ffmpeg_encoder.cpp
@@ -1480,7 +1480,7 @@ int CFFEncoder::init_codec(int idx, AVFrame *frame) {
 
         #ifdef BMF_FFMPEG_VERSION
             #if BMF_FFMPEG_VERSION < 50
-                out_stream->time_base = enc_ctxs_[idx]->time_base;
+                out_stream->codec->time_base = enc_ctxs_[idx]->time_base;
             #endif
         #endif
     }

--- a/bmf/c_modules/src/ffmpeg_encoder.cpp
+++ b/bmf/c_modules/src/ffmpeg_encoder.cpp
@@ -1478,11 +1478,11 @@ int CFFEncoder::init_codec(int idx, AVFrame *frame) {
             }
         }
 
-        /**
-        * @deprecated codec has been deprecated since ffmpeg 5.0
-        * use out_stream->time_base instead of out_stream->codec->time_base.
-        */
-        out_stream->time_base = enc_ctxs_[idx]->time_base;
+        #ifdef BMF_FFMPEG_VERSION
+            #if BMF_FFMPEG_VERSION < 50
+                out_stream->time_base = enc_ctxs_[idx]->time_base;
+            #endif
+        #endif
     }
 
     out_stream->time_base = enc_ctxs_[idx]->time_base;

--- a/bmf/c_modules/src/ffmpeg_encoder.cpp
+++ b/bmf/c_modules/src/ffmpeg_encoder.cpp
@@ -1478,7 +1478,11 @@ int CFFEncoder::init_codec(int idx, AVFrame *frame) {
             }
         }
 
-        out_stream->codec->time_base = enc_ctxs_[idx]->time_base;
+        /**
+        * @deprecated codec has been deprecated since ffmpeg 5.0
+        * use out_stream->time_base instead of out_stream->codec->time_base.
+        */
+        out_stream->time_base = enc_ctxs_[idx]->time_base;
     }
 
     out_stream->time_base = enc_ctxs_[idx]->time_base;

--- a/bmf/sdk/cpp_sdk/include/bmf/sdk/filter_graph.h
+++ b/bmf/sdk/cpp_sdk/include/bmf/sdk/filter_graph.h
@@ -36,6 +36,7 @@ extern "C" {
 #include <libavutil/bprint.h>
 #include <libswscale/swscale.h>
 #include <libavutil/opt.h>
+#include <libavutil/channel_layout.h>
 #include <libavutil/error.h>
 };
 


### PR DESCRIPTION
This PR aim to fix [#131 issue](https://github.com/BabitMF/bmf/issues/131) that `‘av_get_default_channel_layout’ was not declared` and `‘AVStream’ {aka ‘struct AVStream’} has no member named ‘codec’` if we compile bmf with ffmpeg 5.x.x
## Key change 
* add <libavutil/channel_layout.h> into filter_graph.h
* deprecate AVStream->codec 

The following is the compilation error log
```bash
In file included from /home/jack/Documents/workspace/fork/bmf/bmf/sdk/cpp_sdk/include/bmf/sdk/simple_filter_graph.h:24,
                 from /home/jack/Documents/workspace/fork/bmf/bmf/sdk/cpp_sdk/include/bmf/sdk/ffmpeg_helper.h:24,
                 from /home/jack/Documents/workspace/fork/bmf/bmf/sdk/cpp_sdk/test/test_audio_frame.cpp:19:
/home/jack/Documents/workspace/fork/bmf/bmf/sdk/cpp_sdk/include/bmf/sdk/filter_graph.h: In member function ‘int bmf_sdk::FilterGraph::config_graph(std::string&, std::map<int, bmf_sdk::FilterConfig>&, std::map<int, bmf_sdk::FilterConfig>&)’:
/home/jack/Documents/workspace/fork/bmf/bmf/sdk/cpp_sdk/include/bmf/sdk/filter_graph.h:270:29: error: ‘av_get_default_channel_layout’ was not declared in this scope; did you mean ‘av_opt_set_channel_layout’?
  270 |                             av_get_default_channel_layout(
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                             av_opt_set_channel_layout
In file included from /home/jack/Documents/workspace/fork/bmf/bmf/c_modules/include/ffmpeg_decoder.h:19,
                 from /home/jack/Documents/workspace/fork/bmf/bmf/c_modules/src/ffmpeg_decoder.cpp:16:
/home/jack/Documents/workspace/fork/bmf/bmf/sdk/cpp_sdk/include/bmf/sdk/filter_graph.h: In member function ‘int bmf_sdk::FilterGraph::config_graph(std::string&, std::map<int, bmf_sdk::FilterConfig>&, std::map<int, bmf_sdk::FilterConfig>&)’:
/home/jack/Documents/workspace/fork/bmf/bmf/sdk/cpp_sdk/include/bmf/sdk/filter_graph.h:270:29: error: ‘av_get_default_channel_layout’ was not declared in this scope; did you mean ‘av_opt_set_channel_layout’?
  270 |                             av_get_default_channel_layout(
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                             av_opt_set_channel_layout
In file included from /home/jack/Documents/workspace/fork/bmf/bmf/sdk/cpp_sdk/include/bmf/sdk/ffmpeg_helper.h:27,
                 from /home/jack/Documents/workspace/fork/bmf/bmf/sdk/cpp_sdk/test/test_audio_frame.cpp:19:
/home/jack/Documents/workspace/fork/bmf/bmf/hml/include/hmp/ffmpeg/ff_helper.h: In function ‘AVFrame* hmp::ffmpeg::to_audio_frame(const TensorList&, const AVFrame*, bool)’:
/home/jack/Documents/workspace/fork/bmf/bmf/hml/include/hmp/ffmpeg/ff_helper.h:378:26: error: ‘av_get_channel_layout_nb_channels’ was not declared in this scope
  378 |                        : av_get_channel_layout_nb_channels(avf->channel_layout);
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/jack/Documents/workspace/fork/bmf/bmf/hml/third_party/gtest/googletest/include/gtest/gtest.h:387,
                 from /home/jack/Documents/workspace/fork/bmf/bmf/sdk/cpp_sdk/test/test_audio_frame.cpp:21:
/home/jack/Documents/workspace/fork/bmf/bmf/sdk/cpp_sdk/test/test_audio_frame.cpp: In member function ‘virtual void audio_frame_ffmpeg_interop_Test::TestBody()’:
/home/jack/Documents/workspace/fork/bmf/bmf/sdk/cpp_sdk/test/test_audio_frame.cpp:86:41: error: ‘AV_CH_LAYOUT_STEREO’ was not declared in this scope
   86 |         EXPECT_EQ(aaf0->channel_layout, AV_CH_LAYOUT_STEREO);
      |                                         ^~~~~~~~~~~~~~~~~~~
/home/jack/Documents/workspace/fork/bmf/bmf/sdk/cpp_sdk/test/test_audio_frame.cpp:123:41: error: ‘AV_CH_LAYOUT_STEREO’ was not declared in this scope
  123 |         EXPECT_EQ(aaf0->channel_layout, AV_CH_LAYOUT_STEREO);
      |                                         ^~~~~~~~~~~~~~~~~~~
/home/jack/Documents/workspace/fork/bmf/bmf/sdk/cpp_sdk/test/test_audio_frame.cpp:156:41: error: ‘AV_CH_LAYOUT_HEXADECAGONAL’ was not declared in this scope
  156 |         EXPECT_EQ(aaf0->channel_layout, AV_CH_LAYOUT_HEXADECAGONAL);
      |                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/jack/Documents/workspace/fork/bmf/bmf/engine/c_engine/src/loader/py_module_loader.cpp:178:7: warning: ‘bmf_sdk::PyModuleFactory’ declared with greater visibility than the type of its field ‘bmf_sdk::PyModuleFactory::factory_’ [-Wattributes]
  178 | class PyModuleFactory : public ModuleFactoryI {
      |       ^~~~~~~~~~~~~~~
[ 61%] Linking CXX shared library ../../../output/bmf/lib/_hmp.cpython-39-x86_64-linux-gnu.so
make[2]: *** [bmf/sdk/CMakeFiles/test_bmf_module_sdk.dir/build.make:76: bmf/sdk/CMakeFiles/test_bmf_module_sdk.dir/cpp_sdk/test/test_audio_frame.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:979: bmf/sdk/CMakeFiles/test_bmf_module_sdk.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
[ 62%] Building CXX object bmf/engine/c_engine/CMakeFiles/engine.dir/__/connector/src/builder.cpp.o
[ 62%] Linking CXX shared library ../../../output/bmf/lib/libcvtcolor.so
[ 62%] Built target cvtcolor
[ 62%] Building CXX object bmf/engine/c_engine/CMakeFiles/engine.dir/__/connector/src/connector.cpp.o
[ 62%] Linking CXX shared library ../../../output/bmf/lib/libcopy_module.so
[ 62%] Linking CXX shared library ../../output/bmf/cpp_modules/Module_clock/libclock.so
[ 62%] Built target copy_module
[ 62%] Building CXX object bmf/c_modules/CMakeFiles/builtin_modules.dir/src/ffmpeg_encoder.cpp.o
[ 62%] Linking CXX shared library ../../../output/bmf/lib/libbmf_go_loader.so
[ 62%] Built target clock
[ 63%] Building CXX object bmf/engine/c_engine/CMakeFiles/engine.dir/__/connector/src/connector_capi.cpp.o
[ 63%] Built target bmf_go_loader
[ 64%] Building CXX object bmf/c_modules/CMakeFiles/builtin_modules.dir/src/ffmpeg_filter.cpp.o
[ 64%] Built target _hmp
[ 64%] Building CXX object bmf/engine/c_engine/CMakeFiles/engine.dir/src/callback_layer.cpp.o
make[2]: *** [bmf/c_modules/CMakeFiles/builtin_modules.dir/build.make:76: bmf/c_modules/CMakeFiles/builtin_modules.dir/src/ffmpeg_decoder.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
[ 65%] Building CXX object bmf/engine/c_engine/CMakeFiles/engine.dir/src/graph.cpp.o
[ 65%] Building CXX object bmf/engine/c_engine/CMakeFiles/engine.dir/src/graph_config.cpp.o
[ 66%] Building CXX object bmf/engine/c_engine/CMakeFiles/engine.dir/src/input_stream.cpp.o
In file included from /home/jack/Documents/workspace/fork/bmf/bmf/c_modules/include/ffmpeg_filter.h:19,
                 from /home/jack/Documents/workspace/fork/bmf/bmf/c_modules/src/ffmpeg_filter.cpp:14:
/home/jack/Documents/workspace/fork/bmf/bmf/sdk/cpp_sdk/include/bmf/sdk/filter_graph.h: In member function ‘int bmf_sdk::FilterGraph::config_graph(std::string&, std::map<int, bmf_sdk::FilterConfig>&, std::map<int, bmf_sdk::FilterConfig>&)’:
/home/jack/Documents/workspace/fork/bmf/bmf/sdk/cpp_sdk/include/bmf/sdk/filter_graph.h:270:29: error: ‘av_get_default_channel_layout’ was not declared in this scope; did you mean ‘av_opt_set_channel_layout’?
  270 |                             av_get_default_channel_layout(
      |                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                             av_opt_set_channel_layout
In file included from /home/jack/Documents/workspace/fork/bmf/bmf/sdk/cpp_sdk/include/bmf/sdk/ffmpeg_helper.h:27,
                 from /home/jack/Documents/workspace/fork/bmf/bmf/c_modules/src/ffmpeg_filter.cpp:16:
/home/jack/Documents/workspace/fork/bmf/bmf/hml/include/hmp/ffmpeg/ff_helper.h: In function ‘AVFrame* hmp::ffmpeg::to_audio_frame(const TensorList&, const AVFrame*, bool)’:
/home/jack/Documents/workspace/fork/bmf/bmf/hml/include/hmp/ffmpeg/ff_helper.h:378:26: error: ‘av_get_channel_layout_nb_channels’ was not declared in this scope
  378 |                        : av_get_channel_layout_nb_channels(avf->channel_layout);
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 67%] Linking CXX shared library ../../output/bmf/cpp_modules/Module_pass_through/libpass_through.so
/home/jack/Documents/workspace/fork/bmf/bmf/c_modules/src/ffmpeg_encoder.cpp: In member function ‘int CFFEncoder::init_codec(int, AVFrame*)’:
/home/jack/Documents/workspace/fork/bmf/bmf/c_modules/src/ffmpeg_encoder.cpp:1481:21: error: ‘AVStream’ {aka ‘struct AVStream’} has no member named ‘codec’
 1481 |         out_stream->codec->time_base = enc_ctxs_[idx]->time_base;
      | 
```