### PR TITLE
Enhance the ability to find the python environment in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -238,7 +238,7 @@ else
         -DCOVERAGE=${COVERAGE_OPTION} \
         -DSANITIZERS=${SANITIZERS} \
         -DFUZZTEST_ENABLE_FUZZING_MODE=${FUZZING_MODE} \
-        -DBMF_PYENV=${BMF_PYVER} \
+        -DBMF_PYENV=$(python${BMF_PYVER} -c "import sys; print('{}.{}'.format(sys.version_info.major, sys.version_info.minor))") \
         -DBMF_LOCAL_DEPENDENCIES=${LOCAL_BUILD} \
         -DBMF_BUILD_VERSION=${BMF_BUILD_VERSION} \
         -DBMF_BUILD_COMMIT=${BMF_BUILD_COMMIT} ${cmake_args} ..

--- a/build.sh
+++ b/build.sh
@@ -128,6 +128,15 @@ then
     (cd 3rd_party/ && wget https://github.com/BabitMF/bmf/releases/download/files/breakpad.tar.xz && tar xvf breakpad.tar.xz)
 fi
 
+BMF_PYVER="3"
+if [[ -z "${BMF_PYTHON_VERSION}" ]]
+then
+    echo "BMF_PYTHON_VERSION is not set, using default Python 3"
+else
+    echo "Compiling for Python ${BMF_PYTHON_VERSION}"
+    BMF_PYVER="${BMF_PYTHON_VERSION}"
+fi
+
 # Generate BMF version
 source ./version.sh
 
@@ -229,7 +238,7 @@ else
         -DCOVERAGE=${COVERAGE_OPTION} \
         -DSANITIZERS=${SANITIZERS} \
         -DFUZZTEST_ENABLE_FUZZING_MODE=${FUZZING_MODE} \
-        -DBMF_PYENV=$(python3 -c "import sys; print('{}.{}'.format(sys.version_info.major, sys.version_info.minor))") \
+        -DBMF_PYENV=${BMF_PYVER} \
         -DBMF_LOCAL_DEPENDENCIES=${LOCAL_BUILD} \
         -DBMF_BUILD_VERSION=${BMF_BUILD_VERSION} \
         -DBMF_BUILD_COMMIT=${BMF_BUILD_COMMIT} ${cmake_args} ..

--- a/version.sh
+++ b/version.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
-if [[ $OS == *Windows* ]]; then
+if [[ $OS == *Windows* ]]; 
+then
     BMF_BUILD_VERSION=$(python setup.py --version)
 else
-    if [[ -z $BMF_PYENV ]]
+    if [[ -z $BMF_PYENV ]]; 
+    then
         BMF_BUILD_VERSION=$(python${BMF_PYVER} setup.py --version)
     else
         BMF_BUILD_VERSION=$(python3 setup.py --version)

--- a/version.sh
+++ b/version.sh
@@ -2,7 +2,11 @@
 if [[ $OS == *Windows* ]]; then
     BMF_BUILD_VERSION=$(python setup.py --version)
 else
-    BMF_BUILD_VERSION=$(python${BMF_PYVER} setup.py --version)
+    if[[ -z $BMF_PYENV ]]
+        BMF_BUILD_VERSION=$(python${BMF_PYVER} setup.py --version)
+    else
+        BMF_BUILD_VERSION=$(python3 setup.py --version)
+    fi
 fi
 
 if echo "Using git: " && git --version

--- a/version.sh
+++ b/version.sh
@@ -2,7 +2,7 @@
 if [[ $OS == *Windows* ]]; then
     BMF_BUILD_VERSION=$(python setup.py --version)
 else
-    if[[ -z $BMF_PYENV ]]
+    if [[ -z $BMF_PYENV ]]
         BMF_BUILD_VERSION=$(python${BMF_PYVER} setup.py --version)
     else
         BMF_BUILD_VERSION=$(python3 setup.py --version)

--- a/version.sh
+++ b/version.sh
@@ -2,7 +2,7 @@
 if [[ $OS == *Windows* ]]; then
     BMF_BUILD_VERSION=$(python setup.py --version)
 else
-    BMF_BUILD_VERSION=$(python3 setup.py --version)
+    BMF_BUILD_VERSION=$(python${BMF_PYVER} setup.py --version)
 fi
 
 if echo "Using git: " && git --version


### PR DESCRIPTION
## Overview
The previous build script did not allow for manual specification of the Python version. In this patch, the `BMF_PYTHON_VERSION` variable is used to pre-set `BMF_PYVER`, which defaults to 3 (same as before).