### PR TITLE
engine/builder: enable module callback can be called in cpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 *.so
 *.sym
 /build*/
+CMakeFiles
+_deps
 !build.gradle
 bmf/c_module_sdk/build
 bmf/c_module_sdk/cmake-build-debug

--- a/bmf/engine/connector/include/builder.hpp
+++ b/bmf/engine/connector/include/builder.hpp
@@ -141,6 +141,9 @@ class RealNode : public std::enable_shared_from_this<RealNode> {
 
     void AddCallback(long long key, bmf::BMFCallback callbackInstance);
 
+    void AddCallback(long long key, 
+                     std::function<bmf_sdk::CBytes(bmf_sdk::CBytes)> callback);
+
     nlohmann::json Dump();
 
     std::shared_ptr<RealNode>
@@ -450,6 +453,9 @@ class BMF_ENGINE_API Node {
 
     void AddCallback(long long key,
                                   const bmf::BMFCallback &callbackInstance);
+
+    void AddCallback(long long key, 
+                     std::function<bmf_sdk::CBytes(bmf_sdk::CBytes)> callback);
 
     void Start();
 

--- a/bmf/engine/connector/src/builder.cpp
+++ b/bmf/engine/connector/src/builder.cpp
@@ -133,9 +133,12 @@ nlohmann::json RealNode::NodeMetaInfo::Dump() {
     nlohmann::json info;
 
     info["premodule_id"] = preModuleUID_;
-    info["callback_bindings"] = nlohmann::json::object();
+    info["callback_binding"] = 
+        nlohmann::json(std::vector<std::string>());
     for (auto &kv : callbackBinding_) {
-        info["callback_bindings"][kv.first] = kv.second;
+        info["callback_binding"].push_back(
+            std::to_string(kv.first) + ":" + std::to_string(kv.second)
+        );
     }
 
     return info;
@@ -227,6 +230,12 @@ void RealNode::AddCallback(long long key, bmf::BMFCallback callbackInstance) {
     metaInfo_.callbackInstances_[key] =
         std::make_shared<bmf::BMFCallback>(callbackInstance);
     metaInfo_.callbackBinding_[key] = callbackInstance.uid();
+}
+void RealNode::AddCallback(long long key, std::function<bmf_sdk::CBytes(bmf_sdk::CBytes)> callback) {
+    auto cb = bmf::BMFCallback(callback);
+    metaInfo_.callbackInstances_[key] =
+        std::make_shared<bmf::BMFCallback>(cb);
+    metaInfo_.callbackBinding_[key] = cb.uid();
 }
 
 std::shared_ptr<RealNode>
@@ -664,6 +673,11 @@ void Node::SetPreModule(const bmf::BMFModule &preModuleInstance) {
 void Node::AddCallback(long long key,
                        const bmf::BMFCallback &callbackInstance) {
     baseP_->AddCallback(key, callbackInstance);
+}
+
+void Node::AddCallback(long long key, 
+                       std::function<bmf_sdk::CBytes(bmf_sdk::CBytes)> callback) {
+    baseP_->AddCallback(key, callback);
 }
 
 void Node::Start() { Stream(0).Start(); }

--- a/bmf/test/cpp_builder/cpp_transcode.cpp
+++ b/bmf/test/cpp_builder/cpp_transcode.cpp
@@ -318,53 +318,52 @@ TEST(cpp_transcode, transcode_with_null_audio) {
                                     " \"30.0662251656\"}");
 }
 
-// TEST(cpp_transcode, transcode_cb) {
-//     std::string output_file = "./cb.mp4";
-//     BMF_CPP_FILE_REMOVE(output_file);
+TEST(cpp_transcode, transcode_cb) {
+    std::string output_file = "./cb.mp4";
+    BMF_CPP_FILE_REMOVE(output_file);
 
-//     nlohmann::json graph_para = {
-//         {"dump_graph", 0}
-//     };
-//     auto graph = bmf::builder::Graph(bmf::builder::NormalMode,
-//     bmf_sdk::JsonParam(graph_para));
+    nlohmann::json graph_para = {
+        {"dump_graph", 0}
+    };
+    auto graph = bmf::builder::Graph(bmf::builder::NormalMode,
+    bmf_sdk::JsonParam(graph_para));
 
-//     nlohmann::json decode_para = {
-//         {"input_path", "../../files/big_bunny_10s_30fps.mp4"},
-//     };
-//     auto video = graph.Decode(bmf_sdk::JsonParam(decode_para));
-//     nlohmann::json encode_para = {
-//         {"output_path", output_file},
-//         {"video_params", {
-//             {"codec", "h264"},
-//             {"width", 320},
-//             {"height", 240},
-//             {"crf", 23},
-//             {"preset", "veryfast"}
-//         }},
-//         {"audio_params", {
-//             {"codec", "aac"},
-//             {"bit_rate", 128000},
-//             {"sample_rate", 44100},
-//             {"channels", 2}
-//         }}
-//     };
-//     auto cb = [](void *, BMFCBytes) -> BMFCBytes {
-//         BMFLOG(BMF_INFO) << "test cb cpp";
-//         uint8_t bytes[] = {97, 98, 99, 100, 101, 0};
-//         return BMFCBytes{bytes, 6};
-//     };
-//     BMFCallbackInstance cb_ = nullptr;
-//     create_callback(cb, nullptr, &cb_);
-//     graph.Encode(video["video"], video["audio"],
-//     bmf_sdk::JsonParam(encode_para)).AddCallback(0, *cb_);
-//     //std::cout << testing::internal::GetCapturedStdout();
-//     graph.Run();
-//     BMF_CPP_FILE_CHECK(
-//         output_file,
-//         "../transcode/cb.mp4|240|320|7.615000|MOV,MP4,M4A,3GP,3G2,MJ2|366635|348991|h264|{\"fps\":
-//         \"30.0662251656\"}"
-//     );
-// }
+    nlohmann::json decode_para = {
+        {"input_path", "../../files/big_bunny_10s_30fps.mp4"},
+    };
+    auto video = graph.Decode(bmf_sdk::JsonParam(decode_para));
+    nlohmann::json encode_para = {
+        {"output_path", output_file},
+        {"video_params", {
+            {"codec", "h264"},
+            {"width", 320},
+            {"height", 240},
+            {"crf", 23},
+            {"preset", "veryfast"}
+        }},
+        {"audio_params", {
+            {"codec", "aac"},
+            {"bit_rate", 128000},
+            {"sample_rate", 44100},
+            {"channels", 2}
+        }}
+    };
+
+    auto callback = [](bmf_sdk::CBytes input) -> bmf_sdk::CBytes  {
+        std::string strInfo;
+        strInfo.assign(reinterpret_cast<const char*>(input.buffer), input.size);
+        BMFLOG(BMF_INFO) << "====Callback==== " << strInfo;
+        return bmf_sdk::CBytes{input.buffer, input.size};
+    };
+
+    graph.Encode(video["video"], video["audio"],
+    bmf_sdk::JsonParam(encode_para)).AddCallback(0, callback);
+    graph.Run();
+    BMF_CPP_FILE_CHECK(output_file, "../transcode/"
+                                "cb.mp4|240|320|10.0|MOV,MP4,"
+                                "M4A,3GP,3G2,MJ2|192235|240486|h264|{\"fps\":"
+                                " \"30.0662251656\"}");
+}
 
 TEST(cpp_transcode, transcode_hls) {
     std::string output_file = "./file000.ts";


### PR DESCRIPTION
add AddCallback interface in cpp builder, fix the callback_binding string
update .gitignore for mac developers
fix cpp_transcode callback case through changing the value of bitrate check