### PR TITLE
Upgrade release pipeline

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -162,10 +162,11 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     #if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
-        name: artifact
         path: dist
+        pattern: Build*
+        merge-multiple: true
 
     - name: Publish package distributions to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/version.sh
+++ b/version.sh
@@ -3,7 +3,11 @@ if [[ $OS == *Windows* ]];
 then
     BMF_BUILD_VERSION=$(python setup.py --version)
 else
-    BMF_BUILD_VERSION=$(cat setup.py | grep "package_version=" | grep -oP '"\K[0-9.]+')
+    if [ "$(uname -s)" = "Darwin" ]; then
+        BMF_BUILD_VERSION=$(awk -F\" '/package_version=/ {print $2}' setup.py)
+    else
+        BMF_BUILD_VERSION=$(cat setup.py | grep "package_version=" | grep -oP '"\K[0-9.]+')
+    fi
 fi
 
 if echo "Using git: " && git --version


### PR DESCRIPTION
1. Fix a problem in version.sh for mac env building
2. upgrade the download-artifact from v3->v4 in build_wheel because v3 has been deprecated