### PR TITLE
feature: move submodule to cmake

### DIFF
--- a/bmf/CMakeLists.txt
+++ b/bmf/CMakeLists.txt
@@ -141,6 +141,20 @@ endif()
 
 # json
 if (BMF_LOCAL_DEPENDENCIES)
+include(FetchContent)
+set(JSON_DOWNLOAD_DIR "${PROJECT_SOURCE_DIR}/3rd_party/json")
+
+FetchContent_Declare(
+    json
+    GIT_REPOSITORY https://github.com/nlohmann/json.git 
+    GIT_TAG v3.11.2
+    SOURCE_DIR ${JSON_DOWNLOAD_DIR}
+)
+
+FetchContent_GetProperties(json)
+if(NOT json_POPULATED)
+    FetchContent_Populate(json)
+endif()
     add_custom_command(TARGET bmf_assem
         POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/3rd_party/json/include

--- a/build.sh
+++ b/build.sh
@@ -116,10 +116,10 @@ done
 
 mkdir -p output
 
-if [[ $LOCAL_BUILD != "OFF" ]];
-then
-  git submodule update --init --recursive
-fi
+# if [[ $LOCAL_BUILD != "OFF" ]];
+# then
+#   git submodule update --init --recursive
+# fi
 
 if [ ! -d "3rd_party/breakpad" ]
 then


### PR DESCRIPTION
To support the feature: move submodule to cmake. There are two submodule in the.gitmodules, gtest and json. 
For the json lib, I obtained the nlohmann/json library from the CMakeLists.txt file in the bmf directory using FetchContent.
For the gtest lib, I notice build_aarch64.sh will copy /usr/local/googletest/ to 3rd_party/gtest.