### PR TITLE
explicitly add download resources link in 'Getting Started' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ This example implements the denoise algorithm as a BMF module, showcasing a BMF 
     - [Face Detect With TensorRT](#face-detect-with-tensorrt)
 
 - [Getting Started](https://babitmf.github.io/docs/bmf/getting_started_yourself/)
+  - [Download Resources](https://github.com/BabitMF/bmf/releases/download/files/files.tar.gz)
   - [Install](https://babitmf.github.io/docs/bmf/getting_started_yourself/install/)
   - [Create a Graph](https://babitmf.github.io/docs/bmf/getting_started_yourself/create_a_graph/)
     - one of transcode example with 3 languages


### PR DESCRIPTION
To address the issue of unclear guidance on resource files mentioned in Issues #66 .
Added the resource download link in the README.md
Besides, I originally intended to add comments in the test code to prompt users on how to obtain resources, but it seems a bit redundant. Or I could add a download resource link in the BabitMF/babitmf.github.io repository and direct the link in the README.md there. Which option do you think is more appropriate? Looking forward to your feedback!