### PR TITLE
Fix ffmpeg with 6.1 and gpu pixformat

### DIFF
--- a/bmf/hmp/include/hmp/ffmpeg/ff_helper.h
+++ b/bmf/hmp/include/hmp/ffmpeg/ff_helper.h
@@ -405,9 +405,9 @@ static AVFrame *to_audio_frame(const TensorList &planes, const AVFrame *avf_ref,
 
     if (planes.size() > FF_ARRAY_ELEMS(avf->buf)) {
         auto nb_extended_buf = planes.size() - FF_ARRAY_ELEMS(avf->buf);
-        avf->extended_buf = (AVBufferRef **)av_mallocz_array(
+        avf->extended_buf = (AVBufferRef **)av_malloc_array(
             nb_extended_buf, sizeof(*avf->extended_buf));
-        avf->extended_data = (uint8_t **)av_mallocz_array(
+        avf->extended_data = (uint8_t **)av_malloc_array(
             planes.size(), sizeof(*avf->extended_data));
         avf->nb_extended_buf = nb_extended_buf;
     } else {

--- a/bmf/python_modules/rotate_gpu/rotate_gpu.py
+++ b/bmf/python_modules/rotate_gpu/rotate_gpu.py
@@ -153,9 +153,7 @@ class rotate_gpu(Module):
                 cvimg_batch_out = cvcuda.ImageBatchVarShape(
                     in_frame.frame().nplanes())
                 # t3 = torch.ones((in_frame.frame().nplanes(),), dtype=torch.double, device='cuda') * self.flip_code
-                if (in_frame.frame().format() == hmp.PixelFormat.kPF_YUV420P
-                        or in_frame.frame().format()
-                        == hmp.PixelFormat.kPF_YUV420P10):
+                if (in_frame.frame().format() == hmp.PixelFormat.kPF_YUV420P):
                     center[1:3] //= 2
                 xform = numpy.zeros((4, 6), dtype='float32')
                 xform[:] = [
@@ -167,8 +165,8 @@ class rotate_gpu(Module):
                 cvxform = cvcuda.as_tensor(hmp.from_numpy(xform).cuda())
 
                 fill = numpy.array((0, 127, 127))
-                if in_frame.frame().format() == hmp.PixelFormat.kPF_YUV420P10:
-                    fill = numpy.array((0, 511, 511))
+                # if in_frame.frame().format() == hmp.PixelFormat.kPF_YUV420P10:
+                #     fill = numpy.array((0, 511, 511))
 
                 for t, f in zip(tensor_list, out_list):
                     cvimg = cvcuda.as_image(t)


### PR DESCRIPTION
This MR fix 2 minor issue
1. fix incompatility with ffmpeg 6.1

solution : use `av_malloc_array` over `av_mallocz_array`

2. fix GPU: AttributeError: type object 'bmf.lib._hmp.PixelFormat' has no attribute 'kPF_YUV420P10' 

Traceback (most recent call last):
  File "/mnt/d/code/bmf/bmf/demo/gpu_module/test_gpu_module.py", line 47, in <module>
    test()
  File "/mnt/d/code/bmf/bmf/demo/gpu_module/test_gpu_module.py", line 43, in test
    }).run())
       ^^^^^
  File "/mnt/d/code/bmf/output/bmf/builder/bmf_stream.py", line 82, in run
    return self.node_.get_graph().run(self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/d/code/bmf/output/bmf/builder/bmf_graph.py", line 748, in run
    self.exec_graph_.close()
  File "/mnt/d/code/bmf/output/bmf/python_modules/Module_rotate_gpu/rotate_gpu.py", line 170, in process
    if in_frame.frame().format() == hmp.PixelFormat.kPF_YUV420P10:
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: type object 'bmf.lib._hmp.PixelFormat' has no attribute 'kPF_YUV420P10'. Did you mean: 'kPF_YUV420P'?